### PR TITLE
Cleanup compiler warnings

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,0 @@
-Copyright (c) 2020 The Arboard ontributors
-
-This software is licensed under either the MIT (see LICENSE-MIT.txt) license
-or the Apache 2.0 (see LICENSE-APACHE.txt) license at your option.

--- a/src/wayland_data_control_clipboard.rs
+++ b/src/wayland_data_control_clipboard.rs
@@ -26,9 +26,7 @@ impl TryInto<copy::ClipboardType> for LinuxClipboardKind {
 		match self {
 			LinuxClipboardKind::Clipboard => Ok(copy::ClipboardType::Regular),
 			LinuxClipboardKind::Primary => Ok(copy::ClipboardType::Primary),
-			LinuxClipboardKind::Secondary => {
-				return Err(Error::ClipboardNotSupported);
-			}
+			LinuxClipboardKind::Secondary => Err(Error::ClipboardNotSupported),
 		}
 	}
 }
@@ -40,9 +38,7 @@ impl TryInto<paste::ClipboardType> for LinuxClipboardKind {
 		match self {
 			LinuxClipboardKind::Clipboard => Ok(paste::ClipboardType::Regular),
 			LinuxClipboardKind::Primary => Ok(paste::ClipboardType::Primary),
-			LinuxClipboardKind::Secondary => {
-				return Err(Error::ClipboardNotSupported);
-			}
+			LinuxClipboardKind::Secondary => Err(Error::ClipboardNotSupported),
 		}
 	}
 }

--- a/src/windows_clipboard.rs
+++ b/src/windows_clipboard.rs
@@ -148,12 +148,13 @@ fn read_cf_dibv5(dibv5: &[u8]) -> Result<ImageData<'static>, Error> {
 
 	let has_profile =
 		header.bV5CSType as i32 == PROFILE_LINKED || header.bV5CSType as i32 == PROFILE_EMBEDDED;
-	let pixel_data_start;
-	if has_profile {
-		pixel_data_start = header.bV5ProfileData as isize + header.bV5ProfileSize as isize;
+
+	let pixel_data_start = if has_profile {
+		header.bV5ProfileData as isize + header.bV5ProfileSize as isize
 	} else {
-		pixel_data_start = header_size as isize;
-	}
+		header_size as isize
+	};
+
 	unsafe {
 		let image_bytes = dibv5.as_ptr().offset(pixel_data_start) as *const _;
 		let hdc = GetDC(std::ptr::null_mut());

--- a/src/x11_clipboard.rs
+++ b/src/x11_clipboard.rs
@@ -305,7 +305,7 @@ impl ClipboardContext {
 				Event::SelectionNotify(event) => {
 					trace!("Read SelectionNotify");
 					let result = self.handle_read_selection_notify(
-						&reader,
+						reader,
 						target_format,
 						&mut using_incr,
 						&mut incr_data,
@@ -327,7 +327,7 @@ impl ClipboardContext {
 				// a PropertyNotify event.
 				Event::PropertyNotify(event) => {
 					let result = self.handle_read_property_notify(
-						&reader,
+						reader,
 						target_format,
 						&mut using_incr,
 						&mut incr_data,


### PR DESCRIPTION
This change cleans up the compiler and clippy warnings that I saw in CI earlier. It also removes an unnecessary license file that was just more work to keep in sync with everything else.