### PR TITLE
Windows clipboard cleanup + fixes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,3 +90,28 @@ jobs:
         with:
           command: test
           args: --all-features
+
+  miri:
+    needs: clippy
+    env:
+      MIRIFLAGS: -Zmiri-symbolic-alignment-check
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        # Currently, only Windows has soundness tests.
+        os: [windows-latest]
+    steps:
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          override: true
+          components: miri
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Check soundness
+        uses: actions-rs/cargo@v1
+        with:
+          command: miri
+          args: test windows_clipboard --features image-data

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,7 +55,6 @@ dependencies = [
  "objc_id",
  "once_cell",
  "parking_lot 0.12.0",
- "scopeguard",
  "simple_logger",
  "thiserror",
  "winapi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [features]
 default = ["image-data"]
-image-data = ["core-graphics", "image", "winapi/minwindef", "winapi/wingdi", "winapi/winnt"]
+image-data = ["core-graphics", "image", "winapi/minwindef", "winapi/wingdi", "winapi/winnt", "scopeguard"]
 wayland-data-control = ["wl-clipboard-rs"]
 
 [dependencies]
@@ -24,11 +24,10 @@ env_logger = "0.9.0"
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.9", features = [
     "basetsd",
-    "stringapiset",
     "winuser",
     "winbase",
 ]}
-scopeguard = "1.1.0"
+scopeguard = { version =  "1.1.0", optional = true }
 clipboard-win = "4.2"
 log = "0.4"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [features]
 default = ["image-data"]
-image-data = ["core-graphics", "image", "winapi/minwindef", "winapi/wingdi", "winapi/winnt", "scopeguard"]
+image-data = ["core-graphics", "image", "winapi/minwindef", "winapi/wingdi", "winapi/winnt"]
 wayland-data-control = ["wl-clipboard-rs"]
 
 [dependencies]
@@ -27,7 +27,6 @@ winapi = { version = "0.3.9", features = [
     "winuser",
     "winbase",
 ]}
-scopeguard = { version =  "1.1.0", optional = true }
 clipboard-win = "4.2"
 log = "0.4"
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -137,3 +137,25 @@ impl<'a> ImageData<'a> {
 		}
 	}
 }
+
+#[cfg(any(windows, target_os = "linux"))]
+pub(crate) struct ScopeGuard<F: FnOnce()> {
+	callback: Option<F>,
+}
+
+#[cfg(any(windows, target_os = "linux"))]
+impl<F: FnOnce()> ScopeGuard<F> {
+	#[cfg_attr(all(windows, not(feature = "image-data")), allow(dead_code))]
+	pub(crate) fn new(callback: F) -> Self {
+		ScopeGuard { callback: Some(callback) }
+	}
+}
+
+#[cfg(any(windows, target_os = "linux"))]
+impl<F: FnOnce()> Drop for ScopeGuard<F> {
+	fn drop(&mut self) {
+		if let Some(callback) = self.callback.take() {
+			(callback)();
+		}
+	}
+}

--- a/src/x11_clipboard.rs
+++ b/src/x11_clipboard.rs
@@ -43,9 +43,9 @@ use x11rb::{
 	COPY_DEPTH_FROM_PARENT, COPY_FROM_PARENT, NONE,
 };
 
+use crate::{common::ScopeGuard, common_linux::into_unknown, Error, LinuxClipboardKind};
 #[cfg(feature = "image-data")]
 use crate::{common_linux::encode_as_png, ImageData};
-use crate::{common_linux::into_unknown, Error, LinuxClipboardKind};
 
 type Result<T, E = Error> = std::result::Result<T, E>;
 
@@ -663,22 +663,6 @@ impl ClipboardContext {
 		Err(Error::Unknown {
 			description: "The handover was not finished and the condvar didn't time out, yet the condvar wait ended. This should be unreachable.".into()
 		})
-	}
-}
-
-struct ScopeGuard<F: FnOnce()> {
-	callback: Option<F>,
-}
-impl<F: FnOnce()> ScopeGuard<F> {
-	fn new(callback: F) -> Self {
-		ScopeGuard { callback: Some(callback) }
-	}
-}
-impl<F: FnOnce()> Drop for ScopeGuard<F> {
-	fn drop(&mut self) {
-		if let Some(callback) = self.callback.take() {
-			(callback)();
-		}
 	}
 }
 


### PR DESCRIPTION
This PR makes some slight cleanups to the Windows clipboard code, along with fixing an alignment soundness bug that Miri reported.

### Cleanup
The majority of the cleanup work was shifting much more responsibility to `win-clipboard` to handle the set/get operations. This allows `arboard` to drop a lot of its Windows-related unsafe blocks in favor of safe code. 

The final change was clarifying the safety of `add_cf_dibv5`. IMO, marking the entire function as `unsafe` was too broad and makes it harder to follow which operations inside are actually unsafe.

### Soundness Fix
While working on this, Miri reported 2 soundness problems.

You can reproduce the Miri finding by:
1. Check out the master branch
2. Copy the `check_win_to_rgba_conversion` test.
3. Run `cargo +nightly miri test check_win_to_rgba_conversion --features image-data`.

The error that I saw locally is the following:
```
cargo +nightly miri test check_win_to_rgba_conversion --features image-data

running 1 test
error: Undefined Behavior: accessing memory with alignment 1, but alignment 4 is required
   --> C:\Users\USER\.rustup\toolchains\nightly-x86_64-pc-windows-msvc\lib\rustlib\src\rust\library\core\src\slice\raw.rs:131:14
    |
131 |     unsafe { &mut *ptr::slice_from_raw_parts_mut(data, len) }
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ accessing memory with alignment 1, but alignment 4 is required
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

    = note: inside `std::slice::from_raw_parts_mut::<u32>` at C:\Users\USER\.rustup\toolchains\nightly-x86_64-pc-windows-msvc\lib\rustlib\src\rust\library\core\src\slice\raw.rs:131:14
note: inside `windows_clipboard::win_to_rgba` at src\windows_clipboard.rs:282:18
   --> src\windows_clipboard.rs:282:18
    |
282 |     let u32pixels = std::slice::from_raw_parts_mut(bytes.as_mut_ptr() as *mut u32, bytes.len() / 4);
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
note: inside `windows_clipboard::tests::check_win_to_rgba_conversion` at src\windows_clipboard.rs:445:12
   --> src\windows_clipboard.rs:445:12
    |
445 |         unsafe { win_to_rgba(&mut data) }
    |                  ^^^^^^^^^^^^^^^^^^^^^^
note: inside closure at src\windows_clipboard.rs:443:2
   --> src\windows_clipboard.rs:443:2
    |
442 |       #[test]
    |       ------- in this procedural macro expansion
443 | /     fn check_win_to_rgba_conversion() {
444 | |         let mut data = DATA;
445 | |         unsafe { win_to_rgba(&mut data) }
446 | |     }
    | |_____^
    = note: this error originates in the attribute macro `test` (in Nightly builds, run with -Z macro-backtrace for more info)

```

A similar error is reported in `rgba_to_win`, but only when running with `-Zmiri-symbolic-alignment-check` set. To fix both of the problems, I switched the code from constructing a new slice to using [`align_to_mut`](https://doc.rust-lang.org/std/primitive.slice.html#method.align_to_mut) to perform a more well-checked cast. If the safety conditions are upheld, then this is correct and won't cause any weird image bugs to occur.

While I was in the functions, I switched the pixel shifting to use safe code instead. They have [similar enough code](https://rust.godbolt.org/z/evWjrxsjr) that there isn't a performance impact from this change.
