### PR TITLE
Prep to release 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v2.1.0 on 2022-09-03
+
+### Changed
+- Updated most dependencies
+- Removed crate deprecation
+- Fixed soundness bug in Windows clipboard
+
 ## v2.0.1 on 2021-11-05
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,7 +43,7 @@ dependencies = [
 
 [[package]]
 name = "arboard"
-version = "2.0.1"
+version = "2.1.0"
 dependencies = [
  "clipboard-win",
  "core-graphics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arboard"
-version = "2.0.1"
+version = "2.1.0"
 authors = ["Artur Kovacs <kovacs.artur.barnabas@gmail.com>", "Avi Weinstock <aweinstock314@gmail.com>", "Arboard contributors"]
 description = "Image and text handling for the OS clipboard."
 repository = "https://github.com/ArturKovacs/arboard"


### PR DESCRIPTION
This PR makes the prep to release a new version of `arboard` on crates.io. The notable changes would be fixing the soundness bug and removing the deprecation off crates.io.

These are the  steps I would take if this is approved, and are the same as what I have been doing for 1Password's other crates:
1. Merge this PR
2. Using GitHub, create a new release tag.
3. Checkout this tag locally
4. Perform a `cargo publish` based on the tag.