### PR TITLE
Remove `once_cell` dependency by using `const_mutex`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,7 +53,6 @@ dependencies = [
  "objc",
  "objc-foundation",
  "objc_id",
- "once_cell",
  "parking_lot 0.12.0",
  "simple_logger",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,6 @@ x11rb = { version = "0.9" }
 wl-clipboard-rs = { version = "0.4.1", optional = true }
 image = { version = "0.23.9", optional = true, default-features = false, features = ["png"] }
 parking_lot = "0.12"
-once_cell = "1.7"
 
 [[example]]
 name = "get_image"

--- a/src/x11_clipboard.rs
+++ b/src/x11_clipboard.rs
@@ -26,7 +26,6 @@ use std::{
 };
 
 use log::{error, trace, warn};
-use once_cell::sync::Lazy;
 use parking_lot::{Condvar, Mutex, MutexGuard, RwLock};
 use x11rb::{
 	connection::Connection,
@@ -49,7 +48,7 @@ use crate::{common_linux::encode_as_png, ImageData};
 
 type Result<T, E = Error> = std::result::Result<T, E>;
 
-static CLIPBOARD: Lazy<Mutex<Option<GlobalClipboard>>> = Lazy::new(|| Mutex::new(None));
+static CLIPBOARD: Mutex<Option<GlobalClipboard>> = parking_lot::const_mutex(None);
 
 x11rb::atom_manager! {
 	pub Atoms: AtomCookies {


### PR DESCRIPTION
`parking_lot` has the nice property that mutexes can be constructed in a `const` context, allowing `Lazy` to be avoided here.