### PR TITLE
Fix warnings and deny future ones in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,26 +35,30 @@ jobs:
           override: true
           components: clippy
       - uses: actions/checkout@v2
+
       - name: Run `cargo clippy` with no features
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --verbose --no-default-features
+          args: --verbose --no-default-features -- -D warnings
+
       - name: Run `cargo clippy` with `image-data` feature
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --verbose --no-default-features --features image-data
+          args: --verbose --no-default-features --features image-data -- -D warnings
+
       - name: Run `cargo clippy` with `wayland-data-control` feature
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --verbose --no-default-features --features wayland-data-control
+          args: --verbose --no-default-features --features wayland-data-control -- -D warnings
+
       - name: Run `cargo clippy` with all features
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --verbose --all-features
+          args: --verbose --all-features -- -D warnings
 
   test:
     needs: clippy

--- a/src/common.rs
+++ b/src/common.rs
@@ -138,12 +138,12 @@ impl<'a> ImageData<'a> {
 	}
 }
 
-#[cfg(any(windows, unix))]
+#[cfg(any(windows, all(unix, not(target_os = "macos"))))]
 pub(crate) struct ScopeGuard<F: FnOnce()> {
 	callback: Option<F>,
 }
 
-#[cfg(any(windows, unix))]
+#[cfg(any(windows, all(unix, not(target_os = "macos"))))]
 impl<F: FnOnce()> ScopeGuard<F> {
 	#[cfg_attr(all(windows, not(feature = "image-data")), allow(dead_code))]
 	pub(crate) fn new(callback: F) -> Self {
@@ -151,7 +151,7 @@ impl<F: FnOnce()> ScopeGuard<F> {
 	}
 }
 
-#[cfg(any(windows, unix))]
+#[cfg(any(windows, all(unix, not(target_os = "macos"))))]
 impl<F: FnOnce()> Drop for ScopeGuard<F> {
 	fn drop(&mut self) {
 		if let Some(callback) = self.callback.take() {


### PR DESCRIPTION
This PR cleans up the single macOS unused code warning that existed on `master` and then modifies the GitHub actions setup to reject future warnings to keep the primary branch clean.