### PR TITLE
Organize platform-specific code in `platform/`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,43 +16,13 @@ pub use common::Error;
 #[cfg(feature = "image-data")]
 pub use common::ImageData;
 
-// Linux backends
-
-#[cfg(all(unix, not(any(target_os = "macos", target_os = "android", target_os = "emscripten")),))]
-mod x11_clipboard;
-
-#[cfg(all(
-	unix,
-	not(any(target_os = "macos", target_os = "android", target_os = "emscripten")),
-	feature = "wayland-data-control"
-))]
-mod wayland_data_control_clipboard;
-
-// Platforms
-
-#[cfg(all(unix, not(any(target_os = "macos", target_os = "android", target_os = "emscripten"))))]
-mod common_linux;
-#[cfg(all(
-	unix,
-	not(any(target_os = "macos", target_os = "android", target_os = "emscripten"))
-))]
-use common_linux as platform;
-
-#[cfg(windows)]
-mod windows_clipboard;
-#[cfg(windows)]
-use windows_clipboard as platform;
-
-#[cfg(target_os = "macos")]
-mod osx_clipboard;
-#[cfg(target_os = "macos")]
-use osx_clipboard as platform;
+mod platform;
 
 #[cfg(all(
 	unix,
 	not(any(target_os = "macos", target_os = "android", target_os = "emscripten")),
 ))]
-pub use common_linux::{GetExtLinux, LinuxClipboardKind, SetExtLinux};
+pub use platform::{GetExtLinux, LinuxClipboardKind, SetExtLinux};
 
 /// The OS independent struct for accessing the clipboard.
 ///

--- a/src/platform/linux/wayland.rs
+++ b/src/platform/linux/wayland.rs
@@ -7,17 +7,17 @@ use wl_clipboard_rs::{
 	utils::is_primary_selection_supported,
 };
 
-use crate::{
-	common::Error,
-	common_linux::{into_unknown, LinuxClipboardKind},
-};
 #[cfg(feature = "image-data")]
-use crate::{common::ImageData, common_linux::encode_as_png};
+use super::encode_as_png;
+use super::{into_unknown, LinuxClipboardKind};
+use crate::common::Error;
+#[cfg(feature = "image-data")]
+use crate::common::ImageData;
 
 #[cfg(feature = "image-data")]
 const MIME_PNG: &str = "image/png";
 
-pub(crate) struct WaylandDataControlClipboardContext {}
+pub(crate) struct Clipboard {}
 
 impl TryInto<copy::ClipboardType> for LinuxClipboardKind {
 	type Error = Error;
@@ -43,7 +43,7 @@ impl TryInto<paste::ClipboardType> for LinuxClipboardKind {
 	}
 }
 
-impl WaylandDataControlClipboardContext {
+impl Clipboard {
 	#[allow(clippy::unnecessary_wraps)]
 	pub(crate) fn new() -> Result<Self, Error> {
 		// Check if it's possible to communicate with the wayland compositor

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -1,0 +1,17 @@
+#[cfg(all(unix, not(any(target_os = "macos", target_os = "android", target_os = "emscripten"))))]
+mod linux;
+#[cfg(all(
+	unix,
+	not(any(target_os = "macos", target_os = "android", target_os = "emscripten"))
+))]
+pub use linux::*;
+
+#[cfg(windows)]
+mod windows;
+#[cfg(windows)]
+pub(crate) use windows::*;
+
+#[cfg(target_os = "macos")]
+mod osx;
+#[cfg(target_os = "macos")]
+pub(crate) use osx::*;

--- a/src/platform/osx.rs
+++ b/src/platform/osx.rs
@@ -8,9 +8,9 @@ the Apache 2.0 or the MIT license at the licensee's choice. The terms
 and conditions of the chosen license apply to this file.
 */
 
-use super::common::Error;
+use crate::common::Error;
 #[cfg(feature = "image-data")]
-use super::common::ImageData;
+use crate::common::ImageData;
 #[cfg(feature = "image-data")]
 use core_graphics::{
 	base::{kCGBitmapByteOrderDefault, kCGImageAlphaLast, kCGRenderingIntentDefault, CGFloat},

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -30,10 +30,10 @@ use winapi::{
 	},
 };
 
-use super::common::Error;
+use crate::common::Error;
 
 #[cfg(feature = "image-data")]
-use super::common::{ImageData, ScopeGuard};
+use crate::common::{ImageData, ScopeGuard};
 
 const MAX_OPEN_ATTEMPTS: usize = 5;
 


### PR DESCRIPTION
This makes all the code for a specific platform easier to find because it’s all in one place. Moving the X11 and Wayland code into a Linux module additionally simplifies lots of the `#[cfg]`s because all the ones that say “enable this on Linux” are implied by the containing `linux` module rather than having to be restated on both the X11 and Wayland modules.

I also renamed `X11ClipboardContext` → `x11::Clipboard` and similarly `WaylandDataControlClipboardContext` → `wayland::Clipboard` to give each of those modules are more consistent API with every other platform-specific module.