### PR TITLE
Refactor and cleanup macOS implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,6 +53,7 @@ dependencies = [
  "objc",
  "objc-foundation",
  "objc_id",
+ "once_cell",
  "parking_lot 0.12.0",
  "simple_logger",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ log = "0.4"
 objc = "0.2"
 objc_id = "0.1"
 objc-foundation = "0.1"
+once_cell = "1"
 core-graphics = { version = "0.22", optional = true }
 image = { version = "0.23", optional = true, default-features = false, features = ["tiff"] }
 


### PR DESCRIPTION
This PR cleans up and significantly refactors the macOS clipboard implementation to be be more idiomatic and easier to maintain.

Some notable changes include:
- Caching Objective-C classes to avoid the lookup cost on every operation.
- Refactoring array accessing
- Refactoring parameter assignment
- Improving result handling