### PR TITLE
Add WindowsSetExt and improve Windows internals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,9 +167,9 @@ dependencies = [
 
 [[package]]
 name = "clipboard-win"
-version = "4.2.1"
+version = "4.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e4ea1881992efc993e4dc50a324cdbd03216e41bdc8385720ff47efc9bd2ca8"
+checksum = "2f3e1238132dc01f081e1cbb9dace14e5ef4c3a51ee244bd982275fb514605db"
 dependencies = [
  "error-code",
  "str-buf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ winapi = { version = "0.3.9", features = [
     "winuser",
     "winbase",
 ]}
-clipboard-win = "4.2"
+clipboard-win = "4.2.2"
 log = "0.4"
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,9 @@ mod platform;
 ))]
 pub use platform::{ClearExtLinux, GetExtLinux, LinuxClipboardKind, SetExtLinux};
 
+#[cfg(windows)]
+pub use platform::SetExtWindows;
+
 /// The OS independent struct for accessing the clipboard.
 ///
 /// Any number of `Clipboard` instances are allowed to exist at a single point in time. Note however

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -9,7 +9,7 @@ pub use linux::*;
 #[cfg(windows)]
 mod windows;
 #[cfg(windows)]
-pub(crate) use windows::*;
+pub use windows::*;
 
 #[cfg(target_os = "macos")]
 mod osx;


### PR DESCRIPTION
This PR does three things:
- Adds a `SetExtWindows` trait
- Reduces the amount of times the Windows clipboard is opened per set of operations
- Makes the Windows clipboard implementation `!Send + !Sync`

Firstly, the addition of the new extension trait is to add support for preventing data set on the Windows clipboard from being synchronized to Microsoft's cloud services or local clipboard history manager. This functionality is desirable in applications that deal with sensitive data, such as as password managers. It would be pretty bad if passwords considered protected ended up in plaintext in OneDrive. Secondly, I refactored the opening of the Windows clipboard to be more consistent with the other platforms by actually opening it when `new()` is called. By keeping the clipboard open between operations, it allows applications to perform multiple operations back-to-back without the worry of being interrupted. 

Finally, I made the `platform::Clipboard` implementation for Windows `!Send + !Sync`. The clipboard on Windows is opened _per thread_, and any operations done on a different thread will always return `ERROR_CLIPBOARD_NOT_OPEN`. To avoid runtime errors, it is now a compile-time error to try and move it between threads. This is a breaking change ~~,but it wouldn't have worked for users on Windows before anyway so  I suspect users may already be dealing with this by using tightly-scoped access to `Clipboard.`~~