### PR TITLE
Accept &str instead of String for setting text

### DIFF
--- a/examples/daemonize.rs
+++ b/examples/daemonize.rs
@@ -14,11 +14,11 @@ const DAEMONIZE_ARG: &str = "__internal_daemonize";
 fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 	#[cfg(target_os = "linux")]
 	if env::args().nth(1).as_deref() == Some(DAEMONIZE_ARG) {
-		Clipboard::new()?.set().wait().text("Hello, world!".into())?;
+		Clipboard::new()?.set().wait().text("Hello, world!")?;
 		return Ok(());
 	}
 
-	let _logger = SimpleLogger::new().init().unwrap();
+	SimpleLogger::new().init().unwrap();
 
 	if cfg!(target_os = "linux") {
 		process::Command::new(env::current_exe()?)
@@ -29,7 +29,7 @@ fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 			.current_dir("/")
 			.spawn()?;
 	} else {
-		Clipboard::new()?.set_text("Hello, world!".into())?;
+		Clipboard::new()?.set_text("Hello, world!")?;
 	}
 
 	Ok(())

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -2,11 +2,11 @@ use arboard::Clipboard;
 use simple_logger::SimpleLogger;
 
 fn main() {
-	let _logger = SimpleLogger::new().init().unwrap();
+	SimpleLogger::new().init().unwrap();
 	let mut clipboard = Clipboard::new().unwrap();
 	println!("Clipboard text was: {:?}", clipboard.get_text());
 
 	let the_string = "Hello, world!";
-	clipboard.set_text(the_string.into()).unwrap();
+	clipboard.set_text(the_string).unwrap();
 	println!("But now the clipboard text should be: \"{}\"", the_string);
 }

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 #[cfg(feature = "image-data")]
 use std::{cell::RefCell, rc::Rc};
 
@@ -172,7 +173,7 @@ impl<'clipboard> Set<'clipboard> {
 		Self { clipboard, wait: false, selection: LinuxClipboardKind::Clipboard }
 	}
 
-	pub(crate) fn text(self, text: String) -> Result<(), Error> {
+	pub(crate) fn text(self, text: Cow<'_, str>) -> Result<(), Error> {
 		match self.clipboard {
 			Clipboard::X11(clipboard) => clipboard.set_text(text, self.selection, self.wait),
 			#[cfg(feature = "wayland-data-control")]
@@ -267,7 +268,7 @@ impl<'clipboard> Clear<'clipboard> {
 	pub(crate) fn clear(self) -> Result<(), Error> {
 		let mut set = Set::new(self.clipboard);
 		set.selection = self.selection;
-		set.text(String::new())
+		set.text(Cow::Borrowed(""))
 	}
 }
 

--- a/src/platform/linux/wayland.rs
+++ b/src/platform/linux/wayland.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::convert::TryInto;
 use std::io::Read;
 
@@ -76,7 +77,7 @@ impl Clipboard {
 
 	pub(crate) fn set_text(
 		&self,
-		text: String,
+		text: Cow<'_, str>,
 		selection: LinuxClipboardKind,
 		wait: bool,
 	) -> Result<(), Error> {
@@ -84,7 +85,7 @@ impl Clipboard {
 		let mut opts = Options::new();
 		opts.foreground(wait);
 		opts.clipboard(selection.try_into()?);
-		let source = Source::Bytes(text.as_bytes().into());
+		let source = Source::Bytes(text.into_owned().into_bytes().into_boxed_slice());
 		opts.copy(source, MimeType::Text).map_err(|e| match e {
 			CopyError::PrimarySelectionUnsupported => Error::ClipboardNotSupported,
 			other => into_unknown(other),

--- a/src/platform/linux/x11.rs
+++ b/src/platform/linux/x11.rs
@@ -13,6 +13,7 @@ and conditions of the chosen license apply to this file.
 // https://freedesktop.org/wiki/ClipboardManager/
 
 use std::{
+	borrow::Cow,
 	cell::RefCell,
 	collections::{hash_map::Entry, HashMap},
 	sync::{
@@ -852,12 +853,14 @@ impl Clipboard {
 
 	pub(crate) fn set_text(
 		&self,
-		message: String,
+		message: Cow<'_, str>,
 		selection: LinuxClipboardKind,
 		wait: bool,
 	) -> Result<()> {
-		let data =
-			ClipboardData { bytes: message.into_bytes(), format: self.inner.atoms.UTF8_STRING };
+		let data = ClipboardData {
+			bytes: message.into_owned().into_bytes(),
+			format: self.inner.atoms.UTF8_STRING,
+		};
 		self.inner.write(data, selection, wait)
 	}
 

--- a/src/platform/osx.rs
+++ b/src/platform/osx.rs
@@ -26,6 +26,7 @@ use objc::{
 use objc_foundation::{INSArray, INSObject, INSString, NSArray, NSDictionary, NSObject, NSString};
 use objc_id::{Id, Owned};
 use once_cell::sync::Lazy;
+use std::borrow::Cow;
 
 // Required to bring NSPasteboard into the path of the class-resolver
 #[link(name = "AppKit", kind = "framework")]
@@ -254,7 +255,7 @@ impl<'clipboard> Set<'clipboard> {
 		Self { clipboard }
 	}
 
-	pub(crate) fn text(self, data: String) -> Result<(), Error> {
+	pub(crate) fn text(self, data: Cow<'_, str>) -> Result<(), Error> {
 		self.clipboard.clear();
 
 		let string_array = NSArray::from_vec(vec![NSString::from_str(&data)]);

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -8,9 +8,9 @@ the Apache 2.0 or the MIT license at the licensee's choice. The terms
 and conditions of the chosen license apply to this file.
 */
 
-use std::marker::PhantomData;
+use std::{borrow::Cow, marker::PhantomData};
 #[cfg(feature = "image-data")]
-use std::{borrow::Cow, convert::TryInto, mem::size_of};
+use std::{convert::TryInto, mem::size_of};
 
 use clipboard_win::Clipboard as SystemClipboard;
 
@@ -461,7 +461,7 @@ impl<'clipboard> Set<'clipboard> {
 		Self { clipboard: PhantomData, exclude_from_cloud: false, exclude_from_history: false }
 	}
 
-	pub(crate) fn text(self, data: String) -> Result<(), Error> {
+	pub(crate) fn text(self, data: Cow<'_, str>) -> Result<(), Error> {
 		clipboard_win::raw::set_string(&data).map_err(|_| Error::Unknown {
 			description: "Could not place the specified text to the clipboard".into(),
 		})?;


### PR DESCRIPTION
This PR migrates the public and private APIs of the crate to accept borrowed strings instead of owned ones when setting text. I did this for two reasons:
- It better (but not exactly) matches the image setting API, which allows you to use borrowed data.
- Avoiding the overhead of cloning values when not needed on most platforms.

The only platform not helped by this change is Linux with X11. It now requires an internal clone of the data passed in since in. Wayland, and the other OSes, already created "platform specific" owned versions prior. 