### PR TITLE
Implement the `.set_html()` method

### DIFF
--- a/examples/set_html.rs
+++ b/examples/set_html.rs
@@ -1,0 +1,15 @@
+use arboard::Clipboard;
+use std::{thread, time::Duration};
+
+fn main() {
+	let mut ctx = Clipboard::new().unwrap();
+
+	let text = "Hello, World!\n\
+        Lorem ipsum dolor sit amet,\n\
+        consectetur adipiscing elit.";
+	let html = "<h1>Hello, World!</h1>\
+        <b>Lorem ipsum</b> dolor sit amet,<br>\
+        <i>consectetur adipiscing elit</i>.";
+	ctx.set_html(html, Some(text)).unwrap();
+	thread::sleep(Duration::from_secs(5));
+}

--- a/examples/set_html.rs
+++ b/examples/set_html.rs
@@ -4,15 +4,16 @@ use std::{thread, time::Duration};
 
 fn main() {
 	SimpleLogger::new().init().unwrap();
-
 	let mut ctx = Clipboard::new().unwrap();
 
-	let text = "Hello, World!\n\
-        Lorem ipsum dolor sit amet,\n\
-        consectetur adipiscing elit.";
-	let html = "<h1>Hello, World!</h1>\
-        <b>Lorem ipsum</b> dolor sit amet,<br>\
-        <i>consectetur adipiscing elit</i>.";
-	ctx.set_html(html, Some(text)).unwrap();
+	let html = r#"<h1>Hello, World!</h1>
+<b>Lorem ipsum</b> dolor sit amet,<br>
+<i>consectetur adipiscing elit</i>."#;
+
+	let alt_text = r#"Hello, World!
+Lorem ipsum dolor sit amet,
+consectetur adipiscing elit."#;
+
+	ctx.set_html(html, Some(alt_text)).unwrap();
 	thread::sleep(Duration::from_secs(5));
 }

--- a/examples/set_html.rs
+++ b/examples/set_html.rs
@@ -1,7 +1,10 @@
 use arboard::Clipboard;
+use simple_logger::SimpleLogger;
 use std::{thread, time::Duration};
 
 fn main() {
+	SimpleLogger::new().init().unwrap();
+
 	let mut ctx = Clipboard::new().unwrap();
 
 	let text = "Hello, World!\n\

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,6 +61,7 @@ impl Clipboard {
 	}
 
 	/// Places the HTML as well as a plain-text alternative onto the clipboard.
+	///
 	/// Any valid utf-8 string is accepted.
 	pub fn set_html<'a, T: Into<Cow<'a, str>>>(
 		&mut self,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -243,6 +243,27 @@ fn all_tests() {
 		// confirm it is OK to clear when already empty.
 		ctx.clear_default().unwrap();
 	}
+	{
+		let mut ctx = Clipboard::new().unwrap();
+		let html = "<b>hello</b> <i>world</i>!";
+
+		ctx.set_html(html, None).unwrap();
+
+		match ctx.get_text() {
+			Ok(text) => assert!(text.is_empty()),
+			Err(Error::ContentNotAvailable) => {}
+			Err(e) => panic!("unexpected error: {}", e),
+		};
+	}
+	{
+		let mut ctx = Clipboard::new().unwrap();
+
+		let html = "<b>hello</b> <i>world</i>!";
+		let alt_text = "hello world!";
+
+		ctx.set_html(html, Some(alt_text)).unwrap();
+		assert_eq!(ctx.get_text().unwrap(), alt_text);
+	}
 	#[cfg(feature = "image-data")]
 	{
 		let mut ctx = Clipboard::new().unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,16 @@ impl Clipboard {
 		self.set().text(text)
 	}
 
+	/// Places the HTML as well as a plain-text alternative onto the clipboard.
+	/// Any valid utf-8 string is accepted.
+	pub fn set_html<'a, T: Into<Cow<'a, str>>>(
+		&mut self,
+		html: T,
+		alt_text: Option<T>,
+	) -> Result<(), Error> {
+		self.set().html(html, alt_text)
+	}
+
 	/// Fetches image data from the clipboard, and returns the decoded pixels.
 	///
 	/// Any image data placed on the clipboard with `set_image` will be possible read back, using
@@ -140,6 +150,18 @@ impl Set<'_> {
 	pub fn text<'a, T: Into<Cow<'a, str>>>(self, text: T) -> Result<(), Error> {
 		let text = text.into();
 		self.platform.text(text)
+	}
+
+	/// Completes the "set" operation by placing HTML as well as a plain-text alternative onto the
+	/// clipboard. Any valid UTF-8 string is accepted.
+	pub fn html<'a, T: Into<Cow<'a, str>>>(
+		self,
+		html: T,
+		alt_text: Option<T>,
+	) -> Result<(), Error> {
+		let html = html.into();
+		let alt_text = alt_text.map(|e| e.into());
+		self.platform.html(html, alt_text)
 	}
 
 	/// Completes the "set" operation by placing an image onto the clipboard.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,7 +153,9 @@ impl Set<'_> {
 	}
 
 	/// Completes the "set" operation by placing HTML as well as a plain-text alternative onto the
-	/// clipboard. Any valid UTF-8 string is accepted.
+	/// clipboard.
+	///
+	/// Any valid UTF-8 string is accepted.
 	pub fn html<'a, T: Into<Cow<'a, str>>>(
 		self,
 		html: T,

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -185,7 +185,7 @@ impl<'clipboard> Set<'clipboard> {
 		match self.clipboard {
 			Clipboard::X11(clipboard) => clipboard.set_html(html, alt, self.selection, self.wait),
 			#[cfg(feature = "wayland-data-control")]
-			Clipboard::WlDataControl(clipboard) => clipboard.set_text(html, self.selection, self.wait),
+			Clipboard::WlDataControl(clipboard) => clipboard.set_html(html, alt, self.selection, self.wait),
 		}
 	}
 

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -181,6 +181,14 @@ impl<'clipboard> Set<'clipboard> {
 		}
 	}
 
+	pub(crate) fn html(self, html: Cow<'_, str>, alt: Option<Cow<'_, str>>) -> Result<(), Error> {
+		match self.clipboard {
+			Clipboard::X11(clipboard) => clipboard.set_html(html, alt, self.selection, self.wait),
+			#[cfg(feature = "wayland-data-control")]
+			Clipboard::WlDataControl(clipboard) => clipboard.set_text(html, self.selection, self.wait),
+		}
+	}
+
 	#[cfg(feature = "image-data")]
 	pub(crate) fn image(self, image: ImageData<'_>) -> Result<(), Error> {
 		match self.clipboard {

--- a/src/platform/linux/wayland.rs
+++ b/src/platform/linux/wayland.rs
@@ -112,18 +112,13 @@ impl Clipboard {
 					MimeSource { source: alt_source, mime_type: MimeType::Text },
 					MimeSource { source: html_source, mime_type: html_mime },
 				])
-				.map_err(|e| match e {
-					CopyError::PrimarySelectionUnsupported => Error::ClipboardNotSupported,
-					other => into_unknown(other),
-				})?;
 			}
-			None => {
-				opts.copy(html_source, html_mime).map_err(|e| match e {
-					CopyError::PrimarySelectionUnsupported => Error::ClipboardNotSupported,
-					other => into_unknown(other),
-				})?;
-			}
-		};
+			None => opts.copy(html_source, html_mime),
+		}
+		.map_err(|e| match e {
+			CopyError::PrimarySelectionUnsupported => Error::ClipboardNotSupported,
+			other => into_unknown(other),
+		})?;
 		Ok(())
 	}
 

--- a/src/platform/linux/wayland.rs
+++ b/src/platform/linux/wayland.rs
@@ -3,7 +3,7 @@ use std::convert::TryInto;
 use std::io::Read;
 
 use wl_clipboard_rs::{
-	copy::{self, Error as CopyError, Options, Source},
+	copy::{self, Error as CopyError, MimeSource, MimeType, Options, Source},
 	paste::{self, get_contents, Error as PasteError, Seat},
 	utils::is_primary_selection_supported,
 };
@@ -81,7 +81,6 @@ impl Clipboard {
 		selection: LinuxClipboardKind,
 		wait: bool,
 	) -> Result<(), Error> {
-		use wl_clipboard_rs::copy::MimeType;
 		let mut opts = Options::new();
 		opts.foreground(wait);
 		opts.clipboard(selection.try_into()?);
@@ -90,6 +89,41 @@ impl Clipboard {
 			CopyError::PrimarySelectionUnsupported => Error::ClipboardNotSupported,
 			other => into_unknown(other),
 		})?;
+		Ok(())
+	}
+
+	pub(crate) fn set_html(
+		&self,
+		html: Cow<'_, str>,
+		alt: Option<Cow<'_, str>>,
+		selection: LinuxClipboardKind,
+		wait: bool,
+	) -> Result<(), Error> {
+		let html_mime = MimeType::Specific(String::from("text/html"));
+		let mut opts = Options::new();
+		opts.foreground(wait);
+		opts.clipboard(selection.try_into()?);
+		let html_source = Source::Bytes(html.into_owned().into_bytes().into_boxed_slice());
+		match alt {
+			Some(alt_text) => {
+				let alt_source =
+					Source::Bytes(alt_text.into_owned().into_bytes().into_boxed_slice());
+				opts.copy_multi(vec![
+					MimeSource { source: alt_source, mime_type: MimeType::Text },
+					MimeSource { source: html_source, mime_type: html_mime },
+				])
+				.map_err(|e| match e {
+					CopyError::PrimarySelectionUnsupported => Error::ClipboardNotSupported,
+					other => into_unknown(other),
+				})?;
+			}
+			None => {
+				opts.copy(html_source, html_mime).map_err(|e| match e {
+					CopyError::PrimarySelectionUnsupported => Error::ClipboardNotSupported,
+					other => into_unknown(other),
+				})?;
+			}
+		};
 		Ok(())
 	}
 
@@ -140,8 +174,6 @@ impl Clipboard {
 		selection: LinuxClipboardKind,
 		wait: bool,
 	) -> Result<(), Error> {
-		use wl_clipboard_rs::copy::MimeType;
-
 		let image = encode_as_png(&image)?;
 		let mut opts = Options::new();
 		opts.foreground(wait);

--- a/src/platform/linux/x11.rs
+++ b/src/platform/linux/x11.rs
@@ -217,7 +217,7 @@ impl Inner {
 
 	fn write(
 		&self,
-		data: &[ClipboardData],
+		data: Vec<ClipboardData>,
 		selection: LinuxClipboardKind,
 		wait: bool,
 	) -> Result<()> {
@@ -241,7 +241,7 @@ impl Inner {
 		// Just setting the data, and the `serve_requests` will take care of the rest.
 		let selection = self.selection_of(selection);
 		let mut data_guard = selection.data.write();
-		*data_guard = Some(data.to_vec());
+		*data_guard = Some(data);
 
 		// Lock the mutex to both ensure that no wakers of `data_changed` can wake us between
 		// dropping the `data_guard` and calling `wait[_for]` and that we don't we wake other
@@ -873,7 +873,7 @@ impl Clipboard {
 			bytes: message.into_owned().into_bytes(),
 			format: self.inner.atoms.UTF8_STRING,
 		}];
-		self.inner.write(&data, selection, wait)
+		self.inner.write(data, selection, wait)
 	}
 
 	pub(crate) fn set_html(
@@ -894,7 +894,7 @@ impl Clipboard {
 			bytes: html.into_owned().into_bytes(),
 			format: self.inner.atoms.HTML,
 		});
-		self.inner.write(&data, selection, wait)
+		self.inner.write(data, selection, wait)
 	}
 
 	#[cfg(feature = "image-data")]
@@ -924,7 +924,7 @@ impl Clipboard {
 	) -> Result<()> {
 		let encoded = encode_as_png(&image)?;
 		let data = vec![ClipboardData { bytes: encoded, format: self.inner.atoms.PNG_MIME }];
-		self.inner.write(&data, selection, wait)
+		self.inner.write(data, selection, wait)
 	}
 }
 

--- a/src/platform/osx.rs
+++ b/src/platform/osx.rs
@@ -31,8 +31,8 @@ use std::borrow::Cow;
 // Required to bring NSPasteboard into the path of the class-resolver
 #[link(name = "AppKit", kind = "framework")]
 extern "C" {
-	static NSPasteboardTypeHTML: &'static Object;
-	static NSPasteboardTypeString: &'static Object;
+	static NSPasteboardTypeHTML: *const Object;
+	static NSPasteboardTypeString: *const Object;
 }
 
 static NSSTRING_CLASS: Lazy<&Class> = Lazy::new(|| Class::get("NSString").unwrap());

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -479,7 +479,7 @@ impl<'clipboard> Set<'clipboard> {
 		})?;
 		if let Some(format) = clipboard_win::register_format("HTML Format") {
 			let html = wrap_html(&html);
-			clipboard_win::raw::set_without_clear(format.get(), &html.into_bytes())
+			clipboard_win::raw::set_without_clear(format.get(), html.as_bytes())
 				.map_err(|e| Error::Unknown { description: e.to_string() })?;
 		}
 		self.add_clipboard_exclusions()?;


### PR DESCRIPTION
This pull request is intended to solve issue #61 by adding new `.set_html()` method that copy HTML content to the clipboard as well as an optional plaintext alternative. The plaintext alternative is useful for programs that do not handle HTML content. Such an interface is already in use on other project like [klembord](https://pypi.org/project/klembord/) (see the `.set_with_rich_text()` method).

## Platforms status

 - [x] Linux (X11)
 - [x] Linux (Wayland)
 - [x] OS X
 - [x] Windows