### PR TITLE
Fix typos and markdowns

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
           override: true
           components: rustfmt
       - uses: actions/checkout@v2
-      - name: Check formating
+      - name: Check formatting
         uses: actions-rs/cargo@v1
         with:
           command: fmt

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This is a cross-platform library for interacting with the clipboard. It allows t
 
 The Linux implementation uses the X protocol by default for managing the clipboard but *fear not*  because Wayland works with the X11 protocol just as well. Furthermore this implementation uses the Clipboard selection (as opposed to the primary selection) and it sends the data to the clipboard manager when the application exits so that the data placed onto the clipboard with your application remains to be available after exiting. 
 
-There's also an optional wayland data control backend through the `wl-clipboard-rs` crate. This can be enabled using the `wayland-data-control` feature. When enabled this will be prioritized over the X11 backend, but if the initialization fails, the implementation falls back to using the X11 protocol automatically. Note that in my tests the wayland backend did not keep the clipboard contets after the process exited. (Although neither did the X11 backend on my Wayland setup).
+There's also an optional wayland data control backend through the `wl-clipboard-rs` crate. This can be enabled using the `wayland-data-control` feature. When enabled this will be prioritized over the X11 backend, but if the initialization fails, the implementation falls back to using the X11 protocol automatically. Note that in my tests the wayland backend did not keep the clipboard contents after the process exited. (Although neither did the X11 backend on my Wayland setup).
 
 ## Example
 

--- a/src/platform/linux/x11.rs
+++ b/src/platform/linux/x11.rs
@@ -242,7 +242,7 @@ impl Inner {
 		let mut guard = selection.mutex.lock();
 
 		// Notify any existing waiting threads that we have changed the data in the selection.
-		// It is important that the mutex is locked to prevent this notication getting lost.
+		// It is important that the mutex is locked to prevent this notification getting lost.
 		selection.data_changed.notify_all();
 
 		if wait {


### PR DESCRIPTION
Found via these commands:

    codespell -L crate,complies
    markdownlint *.md --disable MD024

See a detailed description of the rules is available at
https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md