### PR TITLE
Prep to release 3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,18 @@
 # Changelog
 
+## 3.1 on 2022-20-09
+
+### Changed
+- Updated `image` to the version `0.24`.
+- Lowered Wayland clipboard initialization log level.
+
 ## 3.0 on 2022-19-09
 
 ### Added
 - Support for clearing the clipboard.
 - Spport for excluding Windows clipboard data from cliboard history and OneDrive.
-- Support waiting for another process to read clipboard data before returning from
-a `write` call to a X11 and Wayland or clipboard
+- Support waiting for another process to read clipboard data before returning
+from a `write` call to a X11 and Wayland or clipboard
 
 ### Changed
 - Updated `wl-clipboard-rs` to the version `0.6`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,7 +25,7 @@ dependencies = [
 
 [[package]]
 name = "arboard"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "clipboard-win",
  "core-graphics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arboard"
-version = "3.0.0"
+version = "3.1.0"
 authors = ["Artur Kovacs <kovacs.artur.barnabas@gmail.com>", "Avi Weinstock <aweinstock314@gmail.com>", "Arboard contributors"]
 description = "Image and text handling for the OS clipboard."
 repository = "https://github.com/1Password/arboard"


### PR DESCRIPTION
I chose to use `3.1.0` instead of `3.0.1` because `image` bumped their MSRV quite significantly. `arboard` doesn't currently consider MSRV a breaking change, but its more polite to not bump it in a patch version. 