### PR TITLE
Update `clipboard-win` on Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ winapi = { version = "0.3.9", features = [
     "winuser",
     "winbase",
 ]}
-clipboard-win = "4.2.2"
+clipboard-win = "4.4.2"
 log = "0.4"
 
 [target.'cfg(target_os = "macos")'.dependencies]


### PR DESCRIPTION
This fixed a crash I was experiencing when dealing with very large images on the clipboard.