### PR TITLE
Release 3.1.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,7 +107,7 @@ jobs:
     steps:
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: nightly-2022-10-15
           override: true
           components: miri
 
@@ -118,4 +118,4 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: miri
-          args: test windows_clipboard --features image-data
+          args: test windows --features image-data

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 3.1.1 on 2022-17-10
+
+### Added
+- Implemented the ability to set HTML on the clipboard
+
+### Changed
+- Updated minimum `clipboard-win` version to `4.4`.
+- Updated `wl-clipboard-rs` to the version `0.7`.
+
 ## 3.1 on 2022-20-09
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "arboard"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "clipboard-win",
  "core-graphics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arboard"
-version = "3.1.0"
+version = "3.1.1"
 authors = ["Artur Kovacs <kovacs.artur.barnabas@gmail.com>", "Avi Weinstock <aweinstock314@gmail.com>", "Arboard contributors"]
 description = "Image and text handling for the OS clipboard."
 repository = "https://github.com/1Password/arboard"


### PR DESCRIPTION
Additionally, this PR pins the Nightly toolchain for Windows' Miri testing to `2022-10-15` to avoid failures caused by https://github.com/rust-lang/miri/issues/2599.

Closes https://github.com/1Password/arboard/issues/61