### PR TITLE
Fix Windows clipboard behavior and improve documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 3.2.0
+
+### Changed
+- The Windows clipboard now behaves consistently with the other
+platform implementations again.
+
 ## 3.1.1 on 2022-17-10
 
 ### Added

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -588,7 +588,7 @@ fn add_clipboard_exclusions(
 	Ok(())
 }
 
-/// Windows-specific extensions to the [`Set`](super::Set) builder.
+/// Windows-specific extensions to the [`Set`](crate::Set) builder.
 pub trait SetExtWindows: private::Sealed {
 	/// Excludes the data which will be set on the clipboard from being uploaded to
 	/// the Windows 10/11 [cloud clipboard].


### PR DESCRIPTION
This PR fixes the inconsistent behavior introduced by #60 on Windows that made `arboard`'s semantics entirely different on Windows vs the other platforms, preventing reasonable cross-platform usage.

In addition, it improves the documentation of `Clipboard` to note that your app's usage of arboard may differ depending on what combination of platforms are being targeted. For example, if you're only targeting macOS and Windows, nothing beyond opening and using the clipboard in a one-off fashion is needed. However if Linux is used[^1], then one copy of the clipboard should be kept around at all times.

[^1]: The `SetLinuxExt` builder can help with some of these cases, but is not a universal solution for all apps.

Closes https://github.com/1Password/arboard/issues/88