### PR TITLE
(macOS) Compact HTML formatting for clipboard content

### DIFF
--- a/src/platform/osx.rs
+++ b/src/platform/osx.rs
@@ -280,12 +280,7 @@ impl<'clipboard> Set<'clipboard> {
 		// https://bugzilla.mozilla.org/show_bug.cgi?id=466599
 		// https://bugs.chromium.org/p/chromium/issues/detail?id=11957
 		let html = format!(
-			r#"<html>
-				<head>
-					<meta http-equiv="content-type" content="text/html; charset=utf-8">
-				</head>
-				<body>{}</body>
-			</html>"#,
+			r#"<html><head><meta http-equiv="content-type" content="text/html; charset=utf-8"></head><body>{}</body></html>"#,
 			html
 		);
 		let html_nss = NSString::from_str(&html);


### PR DESCRIPTION
To avoid unexpected behavior in some rich text editors, such as Google Docs, the HTML code used to format clipboard content should be adjusted to avoid creating additional spaces. This pull request updates the formatting of the HTML code to be more compact, while maintaining the same functionality and behavior.

# Environment

- arboard v3.2.0
- macOS 13.2 (Build 22D49)
- rustc 1.67.1 (d5a82bbd2 2023-02-07)
  - binary: rustc
  - commit-hash: d5a82bbd26e1ad8b7401f6a718a9c57c96905483
  - commit-date: 2023-02-07
  - host: aarch64-apple-darwin
  - release: 1.67.1
  - LLVM version: 15.0.6

# Steps to Reproduce

1. Run the following code:

   ```rust
   fn main() {
       arboard::Clipboard::new().unwrap().set_html(r#"<a href="https://github.com/1Password/arboard/">1Password/arbord</a>"#, None).unwrap();
   }
   ```

2. Paste the clipboard content into a Google Document.
3. You will get following result. Unexpected spaces are highlighted in blue. Note that Microsoft Word works fine and is not affected by this change.

    <img width="948" alt="image" src="https://user-images.githubusercontent.com/679719/219522214-6b7ff466-4885-4a60-8496-6bd983330e54.png">