### PR TITLE
fixing doc example so it passes tests on ubuntu

### DIFF
--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -268,7 +268,7 @@ pub trait ClearExtLinux: private::Sealed {
 	///
 	/// ### Example
 	///
-	/// ```
+	/// ```no_run
 	/// # use arboard::{ Clipboard, LinuxClipboardKind, ClearExtLinux, Error };
 	/// # fn main() -> Result<(), Error> {
 	/// let mut clipboard = Clipboard::new()?;

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -268,13 +268,16 @@ pub trait ClearExtLinux: private::Sealed {
 	///
 	/// ### Example
 	///
-	/// ```no_run
-	/// # use arboard::Clipboard;
+	/// ```
+	/// # use arboard::{ Clipboard, LinuxClipboardKind, ClearExtLinux, Error };
+	/// # fn main() -> Result<(), Error> {
 	/// let mut clipboard = Clipboard::new()?;
 	///
 	/// clipboard
 	///     .clear_with()
 	///     .clipboard(LinuxClipboardKind::Secondary)?;
+	/// # Ok(())
+	/// # }
 	/// ```
 	///
 	/// If wayland support is enabled and available, attempting to use the Secondary clipboard will


### PR DESCRIPTION
There isn't a CI test for ubuntu, but they should pass locally.
It failed on compile, so the `no_run` wasn't doing anything helpful.

Just added a main as suggested by the rust docs:
https://doc.rust-lang.org/stable/rustdoc/write-documentation/documentation-tests.html#using--in-doc-tests

And added "use" for missing dependencies.
