### PR TITLE
Remove macOS memory leaks when writing to the clipboard

### DIFF
--- a/tools/debugger.entitlements
+++ b/tools/debugger.entitlements
@@ -1,0 +1,7 @@
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd"\>
+<plist version="1.0">
+    <dict>
+        <key>com.apple.security.get-task-allow</key>
+        <true/>
+    </dict>
+</plist>

--- a/tools/run_with_leaks.sh
+++ b/tools/run_with_leaks.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -euo pipefail
+
+# This script is a utility on Apple platforms to run one
+# of arboard's example binaries under the `leaks` CLI tool,
+# which can help to diagnose memory leakage in any kind of 
+# native or runtime-managed code.
+
+example_name="$@"
+
+script_dir=$(dirname $BASH_SOURCE[0])
+
+# Build the example
+cargo build --example "$example_name"
+
+# Sign it with the required entitlements for process debugging.
+codesign -s - -v -f --entitlements "$script_dir/debugger.entitlements" "./target/debug/examples/$example_name"
+
+# Run the example binary under `leaks` to look for any leaked objects.
+leaks --atExit -- "./target/debug/examples/$example_name"


### PR DESCRIPTION
This PR removes the long-outstanding memory leaks in the macOS clipboard backend. After some experimentation, I found that these methods had leaky implementations:
- `set_string`
- `set_image`
- `set_html`

None of the reading functions had leaks AFAICT.

The root cause of (most) the issues was that several calls to `msg_send!` were not passing their arguments correctly. Instead of passing a pointer to the relevant Objective-C object to a class function, they passed the value itself via move. This worked before since the value could still be read by the system, but it became problematic with memory usage. As the system functions only expected a reference to the data, none of them attempted to free it since this would lead to a use-after-free or double-free in user code. So to Rust's eyes, the value was moved across the FFI boundary and never had their destructors called, essentially the same if `mem::forget` had been used.

To resolve these problems, I corrected the callsites to pass a reference/pointer across like the APIs expected.

The other issue was that when creating an `NSImage` class allocation, the previous code was accidentally increasing the reference count after allocating instead of taking ownership. This resulted in an unbalanced retain count that meant the resulting class could never be freed. Allocating a class always has at least one reference, otherwise it would be instantly reclaimed by the runtime. Our user code becomes the object's new owner once the runtime has finished preparing it.

Relates to #24