### PR TITLE
Remove leaks from macOS clipboard getters

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [features]
 default = ["image-data"]
-image-data = ["core-graphics", "image", "winapi/minwindef", "winapi/wingdi", "winapi/winnt"]
+image-data = ["core-graphics", "once_cell", "image", "winapi/minwindef", "winapi/wingdi", "winapi/winnt"]
 wayland-data-control = ["wl-clipboard-rs"]
 
 [dependencies]
@@ -34,7 +34,7 @@ log = "0.4"
 objc = "0.2"
 objc_id = "0.1"
 objc-foundation = "0.1"
-once_cell = "1"
+once_cell = { version = "1", optional = true }
 core-graphics = { version = "0.22", optional = true }
 image = { version = "0.24", optional = true, default-features = false, features = ["tiff"] }
 


### PR DESCRIPTION
In summary, this PR removes the last of the memory leaks in the macOS clipboard implementation. Specifically, it does two things to accomplish this:

This additionally refactors `image()` to be simpler by taking advantage of the fact that we only want one image. Additionally, this codepath avoids the *highly aggressive* system-level caching of image data that can help reduce peak usage. We have applied an autorelease pool to the Obj-C code as well, as there appear to be a lot of autoreleased values used by AppKit.framework

Finally, it applies a similar refactoring to `text()` for simplicity and removal of memory leaks due to incorrect object retaining assumptions. After a lot of investigation, this seemed to be the best path forward (as previously noted by #97).

Its worth noting that _some_ of the memory growth caused by these functions _would have gone away_ after 5-10 seconds of not calling into the clipboard. However, some use cases require calling into it frequently so this isn't always an option for users. 