### PR TITLE
For consistency use png on macOS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,7 +298,6 @@ dependencies = [
  "num-rational",
  "num-traits",
  "png",
- "tiff",
 ]
 
 [[package]]
@@ -325,12 +324,6 @@ name = "itoa"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
-
-[[package]]
-name = "jpeg-decoder"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9478aa10f73e7528198d75109c8be5cd7d15fb530238040148d5f9a22d4c5b3b"
 
 [[package]]
 name = "lazy_static"
@@ -698,17 +691,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tiff"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7259662e32d1e219321eb309d5f9d898b779769d81b76e762c07c8e5d38fcb65"
-dependencies = [
- "flate2",
- "jpeg-decoder",
- "weezl",
-]
-
-[[package]]
 name = "time"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -804,12 +786,6 @@ checksum = "be12ce1a3c39ec7dba25594b97b42cb3195d54953ddb9d3d95a7c3902bc6e9d4"
 dependencies = [
  "pkg-config",
 ]
-
-[[package]]
-name = "weezl"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9193164d4de03a926d909d3bc7c30543cecb35400c02114792c2cae20d5e2dbb"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ edition = "2018"
 
 [features]
 default = ["image-data"]
-image-data = ["core-graphics", "image", "winapi/minwindef", "winapi/wingdi", "winapi/winnt"]
-wayland-data-control = ["wl-clipboard-rs"]
+image-data = ["dep:core-graphics", "dep:image", "winapi/minwindef", "winapi/wingdi", "winapi/winnt"]
+wayland-data-control = ["dep:wl-clipboard-rs"]
 
 [dependencies]
 thiserror = "1.0"
@@ -36,7 +36,7 @@ objc_id = "0.1"
 objc-foundation = "0.1"
 once_cell = "1"
 core-graphics = { version = "0.22", optional = true }
-image = { version = "0.24", optional = true, default-features = false, features = ["tiff"] }
+image = { version = "0.24", optional = true, default-features = false, features = ["png"] }
 
 [target.'cfg(all(unix, not(any(target_os="macos", target_os="android", target_os="emscripten"))))'.dependencies]
 log = "0.4"

--- a/src/platform/osx.rs
+++ b/src/platform/osx.rs
@@ -227,14 +227,14 @@ impl<'clipboard> Get<'clipboard> {
 			Some(_) | None => return Err(Error::ContentNotAvailable),
 		};
 
-		let tiff: &NSArray<NSObject> = unsafe { msg_send![obj, TIFFRepresentation] };
+		let png: &NSArray<NSObject> = unsafe { msg_send![obj, PNGRepresentation] };
 		let data = unsafe {
-			let len: usize = msg_send![tiff, length];
-			let bytes: *const u8 = msg_send![tiff, bytes];
+			let len: usize = msg_send![png, length];
+			let bytes: *const u8 = msg_send![png, bytes];
 
 			Cursor::new(std::slice::from_raw_parts(bytes, len))
 		};
-		let reader = image::io::Reader::with_format(data, image::ImageFormat::Tiff);
+		let reader = image::io::Reader::with_format(data, image::ImageFormat::Png);
 		match reader.decode() {
 			Ok(img) => {
 				let rgba = img.into_rgba8();


### PR DESCRIPTION
Instead of storing as png on linux and tiff on macos, it feels nicer to just store it as png everywhere.

(haven't tested it yet, but macos docs say this is possible)