### PR TITLE
Remove direct once_cell dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,7 +29,6 @@ dependencies = [
  "objc",
  "objc-foundation",
  "objc_id",
- "once_cell",
  "parking_lot",
  "simple_logger",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [features]
 default = ["image-data"]
-image-data = ["core-graphics", "once_cell", "image", "winapi/minwindef", "winapi/wingdi", "winapi/winnt"]
+image-data = ["core-graphics", "image", "winapi/minwindef", "winapi/wingdi", "winapi/winnt"]
 wayland-data-control = ["wl-clipboard-rs"]
 
 [dependencies]
@@ -34,7 +34,6 @@ log = "0.4"
 objc = "0.2"
 objc_id = "0.1"
 objc-foundation = "0.1"
-once_cell = { version = "1", optional = true }
 core-graphics = { version = "0.22", optional = true }
 image = { version = "0.24", optional = true, default-features = false, features = ["tiff"] }
 

--- a/src/platform/osx.rs
+++ b/src/platform/osx.rs
@@ -26,8 +26,6 @@ use objc::{
 };
 use objc_foundation::{INSArray, INSFastEnumeration, INSString, NSArray, NSObject, NSString};
 use objc_id::{Id, Owned};
-#[cfg(feature = "image-data")]
-use once_cell::sync::Lazy;
 use std::{borrow::Cow, ptr::NonNull};
 
 // Required to bring NSPasteboard into the path of the class-resolver
@@ -38,9 +36,6 @@ extern "C" {
 	#[cfg(feature = "image-data")]
 	static NSPasteboardTypeTIFF: *const Object;
 }
-
-#[cfg(feature = "image-data")]
-static NSIMAGE_CLASS: Lazy<&Class> = Lazy::new(|| Class::get("NSImage").unwrap());
 
 /// Returns an NSImage object on success.
 #[cfg(feature = "image-data")]
@@ -87,8 +82,9 @@ fn image_from_pixels(
 		kCGRenderingIntentDefault,
 	);
 	let size = NSSize { width: width as CGFloat, height: height as CGFloat };
+	let nsimage_class = objc::class!(NSImage);
 	// Take ownership of the newly allocated object, which has an existing retain count.
-	let image: Id<NSObject> = unsafe { Id::from_retained_ptr(msg_send![*NSIMAGE_CLASS, alloc]) };
+	let image: Id<NSObject> = unsafe { Id::from_retained_ptr(msg_send![nsimage_class, alloc]) };
 	#[allow(clippy::let_unit_value)]
 	{
 		// Note: `initWithCGImage` expects a reference (`CGImageRef`), not an actual object.


### PR DESCRIPTION
This PR removes `arboard`'s direct dependency on `once_cell`. It was only used in the macOS clipboard. However, the `class!` macro from the `objc` crate performs the same static caching and is cheaper than `once_cell::Lazy` for our needs. Given that, we can use it instead to get less `cfg` gating in the code.