### PR TITLE
Add support for explicit clipboard monitor excluding on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+- Add support for `ExcludeClipboardContentFromMonitorProcessing` on Windows platforms.
+
 ## 3.2.1 on 2023-28-11
 
 ### Fixed


### PR DESCRIPTION
This PR brings support for setting the `ExcludeClipboardContentFromMonitorProcessing` flag on Windows devices for [removing clipboard contents from monitoring](https://learn.microsoft.com/en-us/windows/win32/dataxchg/clipboard-formats#cloud-clipboard-and-clipboard-history-formats). 

This is a superset of the existing two flags and does the same thing as setting both of them. Additionally though, some third-party clipboard managers may honor this flag in addition to MS's own built-in utilities.

These changes were tested on Windows 10 pro, and were directly compared to the existing history exclusion flag.