### PR TITLE
Make winapi crate optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ thiserror = "1.0"
 env_logger = "0.9.0"
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3.9", features = [
+winapi = { version = "0.3.9", optional = true, features = [
     "basetsd",
     "winuser",
     "winbase",

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -8,7 +8,7 @@ the Apache 2.0 or the MIT license at the licensee's choice. The terms
 and conditions of the chosen license apply to this file.
 */
 
-use std::{borrow::Cow, marker::PhantomData};
+use std::{borrow::Cow, marker::PhantomData, thread, time::Duration};
 #[cfg(feature = "image-data")]
 use std::{convert::TryInto, mem::size_of};
 
@@ -400,8 +400,7 @@ impl Clipboard {
 			}
 
 			// The default value matches Chromium's implementation, but could be tweaked later.
-			// Safety: This is safe to call with any integer.
-			unsafe { winapi::um::synchapi::Sleep(5) };
+			thread::sleep(Duration::from_millis(5));
 		}
 		.map_err(|_| Error::ClipboardOccupied)?;
 


### PR DESCRIPTION
This PR makes winapi crate dependency optional.

Context:

- My application doesn't handle image data. So I use this crate without `image-data` features.
- winapi crate is very inactive (no commit for 3 years). Avoiding it as much as possible would be a good idea.


Without `image-data`, `winapi` is used only for `syncapi::Sleep` in this crate and it can be easily replaced with Rust standard `std::thread::sleep`. `std::thread::sleep` [uses the same `Sleep` C function](https://github.com/rust-lang/rust/blob/3a85a5cfe7884f94e3cb29a606913d7989ad9b48/library/std/src/sys/windows/thread.rs#L100) under the hood. As a side effect, `std::thread::sleep` leverages high-resolution timer. It could make the retry interval more accurate.

This doesn't remove winapi dependency immediately since [clipboard-win](https://crates.io/crates/clipboard-win) v4 still depends on it. However clipboard-win will [replace winapi dependency with windows-rs](https://github.com/DoumanAsh/clipboard-win/commit/ff1a6dd54392d41aa239b6eafc5ed28f9703606b) at next major version v5. When this crate bumps clipboard-win to v5, winapi dependency can be removed along with this PR (without `image-data` feature).

