### PR TITLE
Implement initial MSRV (1.61)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,9 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
+        # Latest stable and MSRV. We only run checks with all features enabled
+        # for the MSRV build to keep CI fast, since other configurations should also work.
+        rust_version: [stable, "1.61"]
     steps:
       - uses: actions-rs/toolchain@v1
         with:
@@ -37,18 +40,21 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Run `cargo clippy` with no features
+        if: ${{ matrix.rust_version == 'stable' }}
         uses: actions-rs/cargo@v1
         with:
           command: clippy
           args: --verbose --no-default-features -- -D warnings -D clippy::dbg_macro
 
       - name: Run `cargo clippy` with `image-data` feature
+        if: ${{ matrix.rust_version == 'stable' }}
         uses: actions-rs/cargo@v1
         with:
           command: clippy
           args: --verbose --no-default-features --features image-data -- -D warnings -D clippy::dbg_macro
 
       - name: Run `cargo clippy` with `wayland-data-control` feature
+        if: ${{ matrix.rust_version == 'stable' }}
         uses: actions-rs/cargo@v1
         with:
           command: clippy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Improved timeout error messaging.
 - Update `wl-clipboard-rs` to `0.8`.
 - Update `x11rb` to `0.12`.
+- `arboard`'s MSRV is now 1.61.
 
 ## 3.2.1 on 2023-29-08
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/1Password/arboard"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 keywords = ["clipboard", "image"]
-edition = "2018"
+edition = "2021"
 rust-version = "1.61"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 keywords = ["clipboard", "image"]
 edition = "2018"
+rust-version = "1.61"
 
 [features]
 default = ["image-data"]

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Latest version](https://img.shields.io/crates/v/arboard?color=mediumvioletred)](https://crates.io/crates/arboard)
 [![Documentation](https://docs.rs/arboard/badge.svg)](https://docs.rs/arboard)
+![MSRV](https://img.shields.io/badge/rustc-1.61+-blue.svg)
 
 ## General
 

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -13,7 +13,7 @@ mod x11;
 mod wayland;
 
 fn into_unknown<E: std::fmt::Display>(error: E) -> Error {
-	Error::Unknown { description: format!("{}", error) }
+	Error::Unknown { description: error.to_string() }
 }
 
 #[cfg(feature = "image-data")]

--- a/src/platform/linux/wayland.rs
+++ b/src/platform/linux/wayland.rs
@@ -71,7 +71,7 @@ impl Clipboard {
 
 			Err(PasteError::PrimarySelectionUnsupported) => Err(Error::ClipboardNotSupported),
 
-			Err(err) => Err(Error::Unknown { description: format!("{}", err) }),
+			Err(err) => Err(Error::Unknown { description: err.to_string() }),
 		}
 	}
 
@@ -154,7 +154,7 @@ impl Clipboard {
 				Err(Error::ContentNotAvailable)
 			}
 
-			Err(err) => Err(Error::Unknown { description: format!("{}", err) }),
+			Err(err) => Err(Error::Unknown { description: err.to_string() }),
 		}
 	}
 

--- a/src/platform/osx.rs
+++ b/src/platform/osx.rs
@@ -282,8 +282,7 @@ impl<'clipboard> Set<'clipboard> {
 		// https://bugzilla.mozilla.org/show_bug.cgi?id=466599
 		// https://bugs.chromium.org/p/chromium/issues/detail?id=11957
 		let html = format!(
-			r#"<html><head><meta http-equiv="content-type" content="text/html; charset=utf-8"></head><body>{}</body></html>"#,
-			html
+			r#"<html><head><meta http-equiv="content-type" content="text/html; charset=utf-8"></head><body>{html}</body></html>"#,
 		);
 		let html_nss = NSString::from_str(&html);
 		// Make sure that we pass a pointer to the string and not the object itself.

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -554,7 +554,7 @@ impl<'clipboard> Set<'clipboard> {
 
 		if let Err(e) = clipboard_win::raw::empty() {
 			return Err(Error::Unknown {
-				description: format!("Failed to empty the clipboard. Got error code: {}", e),
+				description: format!("Failed to empty the clipboard. Got error code: {e}"),
 			});
 		};
 


### PR DESCRIPTION
This PR implements a MSRV for `arboard`, and adds tweaks CI to make sure that it is accounted for. 1.61 was chosen since it is "new enough" and is also the MSRV of our `image` dependency.

It is retroactively applied to the 3.3.x release series since 1.61 is still 1.5 years old.

Closes https://github.com/1Password/arboard/issues/120