### PR TITLE
Update clipboard-win to v5 and replace winapi with windows-sys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,7 +31,7 @@ dependencies = [
  "objc_id",
  "parking_lot",
  "thiserror",
- "winapi",
+ "windows",
  "wl-clipboard-rs",
  "x11rb",
 ]
@@ -544,7 +544,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.48.0",
 ]
 
 [[package]]
@@ -875,12 +875,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
+dependencies = [
+ "windows-core",
+ "windows-targets 0.52.0",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.0",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.0",
 ]
 
 [[package]]
@@ -889,13 +908,28 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.48.0",
+ "windows_aarch64_msvc 0.48.0",
+ "windows_i686_gnu 0.48.0",
+ "windows_i686_msvc 0.48.0",
+ "windows_x86_64_gnu 0.48.0",
+ "windows_x86_64_gnullvm 0.48.0",
+ "windows_x86_64_msvc 0.48.0",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.0",
+ "windows_aarch64_msvc 0.52.0",
+ "windows_i686_gnu 0.52.0",
+ "windows_i686_msvc 0.52.0",
+ "windows_x86_64_gnu 0.52.0",
+ "windows_x86_64_gnullvm 0.52.0",
+ "windows_x86_64_msvc 0.52.0",
 ]
 
 [[package]]
@@ -905,10 +939,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -917,10 +963,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -929,16 +987,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "wl-clipboard-rs"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,7 +31,7 @@ dependencies = [
  "objc_id",
  "parking_lot",
  "thiserror",
- "windows",
+ "windows-sys 0.52.0",
  "wl-clipboard-rs",
  "x11rb",
 ]
@@ -213,7 +213,7 @@ checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
 dependencies = [
  "errno-dragonfly",
  "libc",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -356,7 +356,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d580318f95776505201b28cf98eb1fa5e4be3b689633ba6a3e6cd880ff22d8cb"
 dependencies = [
  "cfg-if",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -515,7 +515,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ae859aa07428ca9a929b936690f8b12dc5f11dd8c6992a18ca93919f28bc177"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -638,7 +638,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -680,7 +680,7 @@ dependencies = [
  "fastrand",
  "redox_syscall",
  "rustix",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -863,31 +863,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
-dependencies = [
- "windows-core",
- "windows-targets 0.52.0",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
-dependencies = [
- "windows-targets 0.52.0",
-]
-
-[[package]]
 name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
  "windows-targets 0.48.0",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,7 +31,7 @@ dependencies = [
  "objc_id",
  "parking_lot",
  "thiserror",
- "windows-sys 0.52.0",
+ "windows-sys",
  "wl-clipboard-rs",
  "x11rb",
 ]
@@ -213,7 +213,7 @@ checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
 dependencies = [
  "errno-dragonfly",
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -356,7 +356,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d580318f95776505201b28cf98eb1fa5e4be3b689633ba6a3e6cd880ff22d8cb"
 dependencies = [
  "cfg-if",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -515,7 +515,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ae859aa07428ca9a929b936690f8b12dc5f11dd8c6992a18ca93919f28bc177"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -538,7 +538,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.48.0",
+ "windows-targets",
 ]
 
 [[package]]
@@ -638,7 +638,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -680,7 +680,7 @@ dependencies = [
  "fastrand",
  "redox_syscall",
  "rustix",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -868,16 +868,7 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets 0.48.0",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.0",
+ "windows-targets",
 ]
 
 [[package]]
@@ -886,28 +877,13 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
 dependencies = [
- "windows_aarch64_gnullvm 0.48.0",
- "windows_aarch64_msvc 0.48.0",
- "windows_i686_gnu 0.48.0",
- "windows_i686_msvc 0.48.0",
- "windows_x86_64_gnu 0.48.0",
- "windows_x86_64_gnullvm 0.48.0",
- "windows_x86_64_msvc 0.48.0",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
-dependencies = [
- "windows_aarch64_gnullvm 0.52.0",
- "windows_aarch64_msvc 0.52.0",
- "windows_i686_gnu 0.52.0",
- "windows_i686_msvc 0.52.0",
- "windows_x86_64_gnu 0.52.0",
- "windows_x86_64_gnullvm 0.52.0",
- "windows_x86_64_msvc 0.52.0",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -917,22 +893,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -941,22 +905,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
-
-[[package]]
 name = "windows_i686_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -965,34 +917,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
 
 [[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
-
-[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "wl-clipboard-rs"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,13 +103,11 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clipboard-win"
-version = "4.4.2"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4ab1b92798304eedc095b53942963240037c0516452cb11aeba709d420b2219"
+checksum = "c57002a5d9be777c1ef967e33674dac9ebd310d8893e4e3437b14d5f0f6372cc"
 dependencies = [
  "error-code",
- "str-buf",
- "winapi",
 ]
 
 [[package]]
@@ -230,13 +228,9 @@ dependencies = [
 
 [[package]]
 name = "error-code"
-version = "2.3.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64f18991e7bf11e7ffee451b5318b5c1a73c52d0d0ada6e5a3017c8c1ced6a21"
-dependencies = [
- "libc",
- "str-buf",
-]
+checksum = "281e452d3bad4005426416cdba5ccfd4f5c1280e10099e21db27f7c1c28347fc"
 
 [[package]]
 name = "fastrand"
@@ -664,12 +658,6 @@ name = "smallvec"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
-
-[[package]]
-name = "str-buf"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e08d8363704e6c71fc928674353e6b7c23dcea9d82d7012c8faf2a3a025f8d0"
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ windows = { version = "0.52.0", optional = true, features = [
     "Win32_System_Memory",
     "Win32_System_Ole",
 ]}
-clipboard-win = "4.4.2"
+clipboard-win = "5.0.0"
 log = "0.4"
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ thiserror = "1.0"
 env_logger = "0.9.0"
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.52.0", optional = true, features = [
+windows-sys = { version = "0.48.0", optional = true, features = [
     "Win32_Foundation",
     "Win32_Graphics_Gdi",
     "Win32_System_DataExchange",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ rust-version = "1.61"
 
 [features]
 default = ["image-data"]
-image-data = ["core-graphics", "image", "winapi/minwindef", "winapi/wingdi", "winapi/winnt"]
+image-data = ["core-graphics", "image", "windows"]
 wayland-data-control = ["wl-clipboard-rs"]
 
 [dependencies]
@@ -22,10 +22,12 @@ thiserror = "1.0"
 env_logger = "0.9.0"
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3.9", optional = true, features = [
-    "basetsd",
-    "winuser",
-    "winbase",
+windows = { version = "0.52.0", optional = true, features = [
+    "Win32_Foundation",
+    "Win32_Graphics_Gdi",
+    "Win32_System_DataExchange",
+    "Win32_System_Memory",
+    "Win32_System_Ole",
 ]}
 clipboard-win = "4.4.2"
 log = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ rust-version = "1.61"
 
 [features]
 default = ["image-data"]
-image-data = ["core-graphics", "image", "windows"]
+image-data = ["core-graphics", "image", "windows-sys"]
 wayland-data-control = ["wl-clipboard-rs"]
 
 [dependencies]
@@ -22,7 +22,7 @@ thiserror = "1.0"
 env_logger = "0.9.0"
 
 [target.'cfg(windows)'.dependencies]
-windows = { version = "0.52.0", optional = true, features = [
+windows-sys = { version = "0.52.0", optional = true, features = [
     "Win32_Foundation",
     "Win32_Graphics_Gdi",
     "Win32_System_DataExchange",

--- a/src/common.rs
+++ b/src/common.rs
@@ -86,7 +86,8 @@ impl std::fmt::Debug for Error {
 }
 
 impl Error {
-	pub fn unknown<M: Into<String>>(message: M) -> Self {
+	#[cfg(windows)]
+	pub(crate) fn unknown<M: Into<String>>(message: M) -> Self {
 		Error::Unknown { description: message.into() }
 	}
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -85,6 +85,12 @@ impl std::fmt::Debug for Error {
 	}
 }
 
+impl Error {
+	pub fn unknown<M: Into<String>>(message: M) -> Self {
+		Error::Unknown { description: message.into() }
+	}
+}
+
 /// Stores pixel data of an image.
 ///
 /// Each element in `bytes` stores the value of a channel of a single pixel.

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -8,341 +8,334 @@ the Apache 2.0 or the MIT license at the licensee's choice. The terms
 and conditions of the chosen license apply to this file.
 */
 
-use std::{borrow::Cow, marker::PhantomData, thread, time::Duration};
 #[cfg(feature = "image-data")]
-use std::{convert::TryInto, mem::size_of};
-
-#[cfg(feature = "image-data")]
-use windows_sys::Win32::{
-	Foundation::GetLastError,
-	Graphics::Gdi::{
-		CreateDIBitmap, DeleteObject, GetDC, GetDIBits, BITMAPINFO, BITMAPINFOHEADER,
-		BITMAPV5HEADER, BI_RGB, CBM_INIT, DIB_RGB_COLORS, LCS_GM_IMAGES, RGBQUAD,
-	},
-	System::{
-		DataExchange::SetClipboardData,
-		Memory::{GlobalLock, GlobalUnlock},
-	},
-};
-
+use crate::common::ImageData;
 use crate::common::{private, Error};
+use std::{borrow::Cow, marker::PhantomData, thread, time::Duration};
 
 #[cfg(feature = "image-data")]
-use crate::common::{ImageData, ScopeGuard};
-
-#[cfg(feature = "image-data")]
-fn last_error(message: &str) -> Error {
-	let code = unsafe { GetLastError() };
-	Error::unknown(format!("{} with error code {:x}", message, code))
-}
-
-#[cfg(feature = "image-data")]
-fn add_cf_dibv5(_open_clipboard: OpenClipboard, image: ImageData) -> Result<(), Error> {
-	use std::intrinsics::copy_nonoverlapping;
+mod image_data {
+	use super::*;
+	use crate::common::ScopeGuard;
+	use std::{convert::TryInto, intrinsics::copy_nonoverlapping, mem::size_of};
 	use windows_sys::Win32::{
-		Graphics::Gdi::BI_BITFIELDS,
+		Foundation::GetLastError,
+		Graphics::Gdi::{
+			CreateDIBitmap, DeleteObject, GetDC, GetDIBits, BITMAPINFO, BITMAPINFOHEADER,
+			BITMAPV5HEADER, BI_BITFIELDS, BI_RGB, CBM_INIT, DIB_RGB_COLORS, LCS_GM_IMAGES, RGBQUAD,
+		},
 		System::{
-			Memory::{GlobalAlloc, GHND},
+			DataExchange::SetClipboardData,
+			Memory::{GlobalAlloc, GlobalLock, GlobalUnlock, GHND},
 			Ole::CF_DIBV5,
 		},
 	};
 
-	// This constant is missing in windows-rs
-	// https://github.com/microsoft/windows-rs/issues/2711
-	#[allow(non_upper_case_globals)]
-	const LCS_sRGB: u32 = 0x7352_4742;
-
-	let header_size = size_of::<BITMAPV5HEADER>();
-	let header = BITMAPV5HEADER {
-		bV5Size: header_size as u32,
-		bV5Width: image.width as i32,
-		bV5Height: image.height as i32,
-		bV5Planes: 1,
-		bV5BitCount: 32,
-		bV5Compression: BI_BITFIELDS,
-		bV5SizeImage: (4 * image.width * image.height) as u32,
-		bV5XPelsPerMeter: 0,
-		bV5YPelsPerMeter: 0,
-		bV5ClrUsed: 0,
-		bV5ClrImportant: 0,
-		bV5RedMask: 0x00ff0000,
-		bV5GreenMask: 0x0000ff00,
-		bV5BlueMask: 0x000000ff,
-		bV5AlphaMask: 0xff000000,
-		bV5CSType: LCS_sRGB,
-		// SAFETY: Windows ignores this field because `bV5CSType` is not set to `LCS_CALIBRATED_RGB`.
-		bV5Endpoints: unsafe { std::mem::zeroed() },
-		bV5GammaRed: 0,
-		bV5GammaGreen: 0,
-		bV5GammaBlue: 0,
-		bV5Intent: LCS_GM_IMAGES as u32, // I'm not sure about this.
-		bV5ProfileData: 0,
-		bV5ProfileSize: 0,
-		bV5Reserved: 0,
-	};
-
-	// In theory we don't need to flip the image because we could just specify
-	// a negative height in the header, which according to the documentation, indicates that the
-	// image rows are in top-to-bottom order. HOWEVER: MS Word (and WordPad) cannot paste an image
-	// that has a negative height in its header.
-	let image = flip_v(image);
-
-	let data_size = header_size + image.bytes.len();
-	let hdata = unsafe { GlobalAlloc(GHND, data_size) };
-	if hdata.is_null() {
-		return Err(last_error("Could not allocate global memory object"));
-	}
-	unsafe {
-		let data_ptr = GlobalLock(hdata) as *mut u8;
-		if data_ptr.is_null() {
-			return Err(last_error("Could not lock the global memory object"));
-		}
-
-		let _unlock = ScopeGuard::new(|| {
-			if GlobalUnlock(hdata) == 0 {
-				log::error!("Failed calling GlobalUnlock when writing dibv5 data");
-			}
-		});
-
-		copy_nonoverlapping::<u8>((&header) as *const _ as *const u8, data_ptr, header_size);
-
-		// Not using the `add` function, because that has a restriction, that the result cannot overflow isize
-		let pixels_dst = (data_ptr as usize + header_size) as *mut u8;
-		copy_nonoverlapping::<u8>(image.bytes.as_ptr(), pixels_dst, image.bytes.len());
-
-		let dst_pixels_slice = std::slice::from_raw_parts_mut(pixels_dst, image.bytes.len());
-
-		// If the non-allocating version of the function failed, we need to assign the new bytes to
-		// the global allocation.
-		if let Cow::Owned(new_pixels) = rgba_to_win(dst_pixels_slice) {
-			// SAFETY: `data_ptr` is valid to write to and has no outstanding mutable borrows, and
-			// `new_pixels` will be the same length as the original bytes.
-			copy_nonoverlapping::<u8>(new_pixels.as_ptr(), data_ptr, new_pixels.len())
-		}
+	fn last_error(message: &str) -> Error {
+		let code = unsafe { GetLastError() };
+		Error::unknown(format!("{} with error code {:x}", message, code))
 	}
 
-	unsafe {
-		if SetClipboardData(CF_DIBV5 as u32, hdata as _) == 0 {
-			DeleteObject(hdata as _);
-			return Err(last_error("SetClipboardData failed with error"));
-		}
-	}
+	pub fn add_cf_dibv5(_open_clipboard: OpenClipboard, image: ImageData) -> Result<(), Error> {
+		// This constant is missing in windows-rs
+		// https://github.com/microsoft/windows-rs/issues/2711
+		#[allow(non_upper_case_globals)]
+		const LCS_sRGB: u32 = 0x7352_4742;
 
-	Ok(())
-}
-
-#[cfg(feature = "image-data")]
-fn read_cf_dibv5(dibv5: &[u8]) -> Result<ImageData<'static>, Error> {
-	// The DIBV5 format is a BITMAPV5HEADER followed by the pixel data according to
-	// https://docs.microsoft.com/en-us/windows/win32/dataxchg/standard-clipboard-formats
-
-	// These constants are missing in windows-rs
-	const PROFILE_EMBEDDED: u32 = 0x4D42_4544;
-	const PROFILE_LINKED: u32 = 0x4C49_4E4B;
-
-	// so first let's get a pointer to the header
-	let header_size = size_of::<BITMAPV5HEADER>();
-	if dibv5.len() < header_size {
-		return Err(Error::unknown("When reading the DIBV5 data, it contained fewer bytes than the BITMAPV5HEADER size. This is invalid."));
-	}
-	let header = unsafe { &*(dibv5.as_ptr() as *const BITMAPV5HEADER) };
-
-	let has_profile = header.bV5CSType == PROFILE_LINKED || header.bV5CSType == PROFILE_EMBEDDED;
-
-	let pixel_data_start = if has_profile {
-		header.bV5ProfileData as isize + header.bV5ProfileSize as isize
-	} else {
-		header_size as isize
-	};
-
-	unsafe {
-		let image_bytes = dibv5.as_ptr().offset(pixel_data_start) as *const _;
-		let hdc = GetDC(0);
-		if hdc == 0 {
-			return Err(Error::unknown("Failed to get the device context. GetDC returned null"));
-		}
-
-		let hbitmap = CreateDIBitmap(
-			hdc,
-			header as *const BITMAPV5HEADER as *const _,
-			CBM_INIT as u32,
-			image_bytes,
-			header as *const BITMAPV5HEADER as *const _,
-			DIB_RGB_COLORS,
-		);
-		if hbitmap == 0 {
-			return Err(Error::unknown(
-				"Failed to create the HBITMAP while reading DIBV5. CreateDIBitmap returned null",
-			));
-		}
-		// Now extract the pixels in a desired format
-		let w = header.bV5Width;
-		let h = header.bV5Height.abs();
-		let result_size = w as usize * h as usize * 4;
-
-		let mut result_bytes = Vec::<u8>::with_capacity(result_size);
-
-		let mut output_header = BITMAPINFO {
-			bmiColors: [RGBQUAD { rgbRed: 0, rgbGreen: 0, rgbBlue: 0, rgbReserved: 0 }],
-			bmiHeader: BITMAPINFOHEADER {
-				biSize: size_of::<BITMAPINFOHEADER>() as u32,
-				biWidth: w,
-				biHeight: -h,
-				biBitCount: 32,
-				biPlanes: 1,
-				biCompression: BI_RGB,
-				biSizeImage: 0,
-				biXPelsPerMeter: 0,
-				biYPelsPerMeter: 0,
-				biClrUsed: 0,
-				biClrImportant: 0,
-			},
+		let header_size = size_of::<BITMAPV5HEADER>();
+		let header = BITMAPV5HEADER {
+			bV5Size: header_size as u32,
+			bV5Width: image.width as i32,
+			bV5Height: image.height as i32,
+			bV5Planes: 1,
+			bV5BitCount: 32,
+			bV5Compression: BI_BITFIELDS,
+			bV5SizeImage: (4 * image.width * image.height) as u32,
+			bV5XPelsPerMeter: 0,
+			bV5YPelsPerMeter: 0,
+			bV5ClrUsed: 0,
+			bV5ClrImportant: 0,
+			bV5RedMask: 0x00ff0000,
+			bV5GreenMask: 0x0000ff00,
+			bV5BlueMask: 0x000000ff,
+			bV5AlphaMask: 0xff000000,
+			bV5CSType: LCS_sRGB,
+			// SAFETY: Windows ignores this field because `bV5CSType` is not set to `LCS_CALIBRATED_RGB`.
+			bV5Endpoints: unsafe { std::mem::zeroed() },
+			bV5GammaRed: 0,
+			bV5GammaGreen: 0,
+			bV5GammaBlue: 0,
+			bV5Intent: LCS_GM_IMAGES as u32, // I'm not sure about this.
+			bV5ProfileData: 0,
+			bV5ProfileSize: 0,
+			bV5Reserved: 0,
 		};
 
-		let result = GetDIBits(
-			hdc,
-			hbitmap,
-			0,
-			h as u32,
-			result_bytes.as_mut_ptr() as *mut _,
-			&mut output_header as *mut _,
-			DIB_RGB_COLORS,
-		);
-		if result == 0 {
-			return Err(Error::unknown("Could not get the bitmap bits, GetDIBits returned 0"));
+		// In theory we don't need to flip the image because we could just specify
+		// a negative height in the header, which according to the documentation, indicates that the
+		// image rows are in top-to-bottom order. HOWEVER: MS Word (and WordPad) cannot paste an image
+		// that has a negative height in its header.
+		let image = flip_v(image);
+
+		let data_size = header_size + image.bytes.len();
+		let hdata = unsafe { GlobalAlloc(GHND, data_size) };
+		if hdata.is_null() {
+			return Err(last_error("Could not allocate global memory object"));
 		}
-		let read_len = result as usize * w as usize * 4;
-		assert!(
-			read_len <= result_bytes.capacity(),
-			"Segmentation fault. Read more bytes than allocated to pixel buffer",
-		);
-		result_bytes.set_len(read_len);
+		unsafe {
+			let data_ptr = GlobalLock(hdata) as *mut u8;
+			if data_ptr.is_null() {
+				return Err(last_error("Could not lock the global memory object"));
+			}
 
-		let result_bytes = win_to_rgba(&mut result_bytes);
+			let _unlock = ScopeGuard::new(|| {
+				if GlobalUnlock(hdata) == 0 {
+					log::error!("Failed calling GlobalUnlock when writing dibv5 data");
+				}
+			});
 
-		let result =
-			ImageData { bytes: Cow::Owned(result_bytes), width: w as usize, height: h as usize };
-		Ok(result)
-	}
-}
+			copy_nonoverlapping::<u8>((&header) as *const _ as *const u8, data_ptr, header_size);
 
-/// Converts the RGBA (u8) pixel data into the bitmap-native ARGB (u32) format in-place
-///
-/// Safety: the `bytes` slice must have a length that's a multiple of 4
-#[cfg(feature = "image-data")]
-#[allow(clippy::identity_op, clippy::erasing_op)]
-#[must_use]
-unsafe fn rgba_to_win(bytes: &mut [u8]) -> Cow<'_, [u8]> {
-	// Check safety invariants to catch obvious bugs.
-	debug_assert_eq!(bytes.len() % 4, 0);
+			// Not using the `add` function, because that has a restriction, that the result cannot overflow isize
+			let pixels_dst = (data_ptr as usize + header_size) as *mut u8;
+			copy_nonoverlapping::<u8>(image.bytes.as_ptr(), pixels_dst, image.bytes.len());
 
-	let mut u32pixels_buffer = convert_bytes_to_u32s(bytes);
-	let u32pixels = match u32pixels_buffer {
-		ImageDataCow::Borrowed(ref mut b) => b,
-		ImageDataCow::Owned(ref mut b) => b.as_mut_slice(),
-	};
+			let dst_pixels_slice = std::slice::from_raw_parts_mut(pixels_dst, image.bytes.len());
 
-	for p in u32pixels.iter_mut() {
-		let [mut r, mut g, mut b, mut a] = p.to_ne_bytes().map(u32::from);
-		r <<= 2 * 8;
-		g <<= 1 * 8;
-		b <<= 0 * 8;
-		a <<= 3 * 8;
+			// If the non-allocating version of the function failed, we need to assign the new bytes to
+			// the global allocation.
+			if let Cow::Owned(new_pixels) = rgba_to_win(dst_pixels_slice) {
+				// SAFETY: `data_ptr` is valid to write to and has no outstanding mutable borrows, and
+				// `new_pixels` will be the same length as the original bytes.
+				copy_nonoverlapping::<u8>(new_pixels.as_ptr(), data_ptr, new_pixels.len())
+			}
+		}
 
-		*p = r | g | b | a;
+		unsafe {
+			if SetClipboardData(CF_DIBV5 as u32, hdata as _) == 0 {
+				DeleteObject(hdata as _);
+				return Err(last_error("SetClipboardData failed with error"));
+			}
+		}
+
+		Ok(())
 	}
 
-	match u32pixels_buffer {
-		ImageDataCow::Borrowed(_) => Cow::Borrowed(bytes),
-		ImageDataCow::Owned(bytes) => {
-			Cow::Owned(bytes.into_iter().flat_map(|b| b.to_ne_bytes()).collect())
+	pub fn read_cf_dibv5(dibv5: &[u8]) -> Result<ImageData<'static>, Error> {
+		// The DIBV5 format is a BITMAPV5HEADER followed by the pixel data according to
+		// https://docs.microsoft.com/en-us/windows/win32/dataxchg/standard-clipboard-formats
+
+		// These constants are missing in windows-rs
+		const PROFILE_EMBEDDED: u32 = 0x4D42_4544;
+		const PROFILE_LINKED: u32 = 0x4C49_4E4B;
+
+		// so first let's get a pointer to the header
+		let header_size = size_of::<BITMAPV5HEADER>();
+		if dibv5.len() < header_size {
+			return Err(Error::unknown("When reading the DIBV5 data, it contained fewer bytes than the BITMAPV5HEADER size. This is invalid."));
+		}
+		let header = unsafe { &*(dibv5.as_ptr() as *const BITMAPV5HEADER) };
+
+		let has_profile =
+			header.bV5CSType == PROFILE_LINKED || header.bV5CSType == PROFILE_EMBEDDED;
+
+		let pixel_data_start = if has_profile {
+			header.bV5ProfileData as isize + header.bV5ProfileSize as isize
+		} else {
+			header_size as isize
+		};
+
+		unsafe {
+			let image_bytes = dibv5.as_ptr().offset(pixel_data_start) as *const _;
+			let hdc = GetDC(0);
+			if hdc == 0 {
+				return Err(Error::unknown(
+					"Failed to get the device context. GetDC returned null",
+				));
+			}
+
+			let hbitmap = CreateDIBitmap(
+				hdc,
+				header as *const BITMAPV5HEADER as *const _,
+				CBM_INIT as u32,
+				image_bytes,
+				header as *const BITMAPV5HEADER as *const _,
+				DIB_RGB_COLORS,
+			);
+			if hbitmap == 0 {
+				return Err(Error::unknown(
+                    "Failed to create the HBITMAP while reading DIBV5. CreateDIBitmap returned null",
+                ));
+			}
+			// Now extract the pixels in a desired format
+			let w = header.bV5Width;
+			let h = header.bV5Height.abs();
+			let result_size = w as usize * h as usize * 4;
+
+			let mut result_bytes = Vec::<u8>::with_capacity(result_size);
+
+			let mut output_header = BITMAPINFO {
+				bmiColors: [RGBQUAD { rgbRed: 0, rgbGreen: 0, rgbBlue: 0, rgbReserved: 0 }],
+				bmiHeader: BITMAPINFOHEADER {
+					biSize: size_of::<BITMAPINFOHEADER>() as u32,
+					biWidth: w,
+					biHeight: -h,
+					biBitCount: 32,
+					biPlanes: 1,
+					biCompression: BI_RGB,
+					biSizeImage: 0,
+					biXPelsPerMeter: 0,
+					biYPelsPerMeter: 0,
+					biClrUsed: 0,
+					biClrImportant: 0,
+				},
+			};
+
+			let result = GetDIBits(
+				hdc,
+				hbitmap,
+				0,
+				h as u32,
+				result_bytes.as_mut_ptr() as *mut _,
+				&mut output_header as *mut _,
+				DIB_RGB_COLORS,
+			);
+			if result == 0 {
+				return Err(Error::unknown("Could not get the bitmap bits, GetDIBits returned 0"));
+			}
+			let read_len = result as usize * w as usize * 4;
+			assert!(
+				read_len <= result_bytes.capacity(),
+				"Segmentation fault. Read more bytes than allocated to pixel buffer",
+			);
+			result_bytes.set_len(read_len);
+
+			let result_bytes = win_to_rgba(&mut result_bytes);
+
+			let result = ImageData {
+				bytes: Cow::Owned(result_bytes),
+				width: w as usize,
+				height: h as usize,
+			};
+			Ok(result)
 		}
 	}
-}
 
-/// Vertically flips the image pixels in memory
-#[cfg(feature = "image-data")]
-fn flip_v(image: ImageData) -> ImageData<'static> {
-	let w = image.width;
-	let h = image.height;
+	/// Converts the RGBA (u8) pixel data into the bitmap-native ARGB (u32) format in-place
+	///
+	/// Safety: the `bytes` slice must have a length that's a multiple of 4
+	#[allow(clippy::identity_op, clippy::erasing_op)]
+	#[must_use]
+	unsafe fn rgba_to_win(bytes: &mut [u8]) -> Cow<'_, [u8]> {
+		// Check safety invariants to catch obvious bugs.
+		debug_assert_eq!(bytes.len() % 4, 0);
 
-	let mut bytes = image.bytes.into_owned();
+		let mut u32pixels_buffer = convert_bytes_to_u32s(bytes);
+		let u32pixels = match u32pixels_buffer {
+			ImageDataCow::Borrowed(ref mut b) => b,
+			ImageDataCow::Owned(ref mut b) => b.as_mut_slice(),
+		};
 
-	let rowsize = w * 4; // each pixel is 4 bytes
-	let mut tmp_a = vec![0; rowsize];
-	// I believe this could be done safely with `as_chunks_mut`, but that's not stable yet
-	for a_row_id in 0..(h / 2) {
-		let b_row_id = h - a_row_id - 1;
+		for p in u32pixels.iter_mut() {
+			let [mut r, mut g, mut b, mut a] = p.to_ne_bytes().map(u32::from);
+			r <<= 2 * 8;
+			g <<= 1 * 8;
+			b <<= 0 * 8;
+			a <<= 3 * 8;
 
-		// swap rows `first_id` and `second_id`
-		let a_byte_start = a_row_id * rowsize;
-		let a_byte_end = a_byte_start + rowsize;
-		let b_byte_start = b_row_id * rowsize;
-		let b_byte_end = b_byte_start + rowsize;
-		tmp_a.copy_from_slice(&bytes[a_byte_start..a_byte_end]);
-		bytes.copy_within(b_byte_start..b_byte_end, a_byte_start);
-		bytes[b_byte_start..b_byte_end].copy_from_slice(&tmp_a);
+			*p = r | g | b | a;
+		}
+
+		match u32pixels_buffer {
+			ImageDataCow::Borrowed(_) => Cow::Borrowed(bytes),
+			ImageDataCow::Owned(bytes) => {
+				Cow::Owned(bytes.into_iter().flat_map(|b| b.to_ne_bytes()).collect())
+			}
+		}
 	}
 
-	ImageData { width: image.width, height: image.height, bytes: bytes.into() }
-}
+	/// Vertically flips the image pixels in memory
+	fn flip_v(image: ImageData) -> ImageData<'static> {
+		let w = image.width;
+		let h = image.height;
 
-/// Converts the ARGB (u32) pixel data into the RGBA (u8) format in-place
-///
-/// Safety: the `bytes` slice must have a length that's a multiple of 4
-#[cfg(feature = "image-data")]
-#[allow(clippy::identity_op, clippy::erasing_op)]
-#[must_use]
-unsafe fn win_to_rgba(bytes: &mut [u8]) -> Vec<u8> {
-	// Check safety invariants to catch obvious bugs.
-	debug_assert_eq!(bytes.len() % 4, 0);
+		let mut bytes = image.bytes.into_owned();
 
-	let mut u32pixels_buffer = convert_bytes_to_u32s(bytes);
-	let u32pixels = match u32pixels_buffer {
-		ImageDataCow::Borrowed(ref mut b) => b,
-		ImageDataCow::Owned(ref mut b) => b.as_mut_slice(),
-	};
+		let rowsize = w * 4; // each pixel is 4 bytes
+		let mut tmp_a = vec![0; rowsize];
+		// I believe this could be done safely with `as_chunks_mut`, but that's not stable yet
+		for a_row_id in 0..(h / 2) {
+			let b_row_id = h - a_row_id - 1;
 
-	for p in u32pixels {
-		let mut bytes = p.to_ne_bytes();
-		bytes[0] = (*p >> (2 * 8)) as u8;
-		bytes[1] = (*p >> (1 * 8)) as u8;
-		bytes[2] = (*p >> (0 * 8)) as u8;
-		bytes[3] = (*p >> (3 * 8)) as u8;
-		*p = u32::from_ne_bytes(bytes);
+			// swap rows `first_id` and `second_id`
+			let a_byte_start = a_row_id * rowsize;
+			let a_byte_end = a_byte_start + rowsize;
+			let b_byte_start = b_row_id * rowsize;
+			let b_byte_end = b_byte_start + rowsize;
+			tmp_a.copy_from_slice(&bytes[a_byte_start..a_byte_end]);
+			bytes.copy_within(b_byte_start..b_byte_end, a_byte_start);
+			bytes[b_byte_start..b_byte_end].copy_from_slice(&tmp_a);
+		}
+
+		ImageData { width: image.width, height: image.height, bytes: bytes.into() }
 	}
 
-	match u32pixels_buffer {
-		ImageDataCow::Borrowed(_) => bytes.to_vec(),
-		ImageDataCow::Owned(bytes) => bytes.into_iter().flat_map(|b| b.to_ne_bytes()).collect(),
+	/// Converts the ARGB (u32) pixel data into the RGBA (u8) format in-place
+	///
+	/// Safety: the `bytes` slice must have a length that's a multiple of 4
+	#[allow(clippy::identity_op, clippy::erasing_op)]
+	#[must_use]
+	unsafe fn win_to_rgba(bytes: &mut [u8]) -> Vec<u8> {
+		// Check safety invariants to catch obvious bugs.
+		debug_assert_eq!(bytes.len() % 4, 0);
+
+		let mut u32pixels_buffer = convert_bytes_to_u32s(bytes);
+		let u32pixels = match u32pixels_buffer {
+			ImageDataCow::Borrowed(ref mut b) => b,
+			ImageDataCow::Owned(ref mut b) => b.as_mut_slice(),
+		};
+
+		for p in u32pixels {
+			let mut bytes = p.to_ne_bytes();
+			bytes[0] = (*p >> (2 * 8)) as u8;
+			bytes[1] = (*p >> (1 * 8)) as u8;
+			bytes[2] = (*p >> (0 * 8)) as u8;
+			bytes[3] = (*p >> (3 * 8)) as u8;
+			*p = u32::from_ne_bytes(bytes);
+		}
+
+		match u32pixels_buffer {
+			ImageDataCow::Borrowed(_) => bytes.to_vec(),
+			ImageDataCow::Owned(bytes) => bytes.into_iter().flat_map(|b| b.to_ne_bytes()).collect(),
+		}
 	}
-}
 
-#[cfg(feature = "image-data")]
-// XXX: std's Cow is not usable here because it does not allow mutably
-// borrowing data.
-enum ImageDataCow<'a> {
-	Borrowed(&'a mut [u32]),
-	Owned(Vec<u32>),
-}
+	// XXX: std's Cow is not usable here because it does not allow mutably
+	// borrowing data.
+	enum ImageDataCow<'a> {
+		Borrowed(&'a mut [u32]),
+		Owned(Vec<u32>),
+	}
 
-/// Safety: the `bytes` slice must have a length that's a multiple of 4
-#[cfg(feature = "image-data")]
-unsafe fn convert_bytes_to_u32s(bytes: &mut [u8]) -> ImageDataCow<'_> {
-	// When the correct conditions are upheld, `std` should return everything in the well-aligned slice.
-	let (prefix, _, suffix) = bytes.align_to::<u32>();
+	/// Safety: the `bytes` slice must have a length that's a multiple of 4
+	unsafe fn convert_bytes_to_u32s(bytes: &mut [u8]) -> ImageDataCow<'_> {
+		// When the correct conditions are upheld, `std` should return everything in the well-aligned slice.
+		let (prefix, _, suffix) = bytes.align_to::<u32>();
 
-	// Check if `align_to` gave us the optimal result.
-	//
-	// If it didn't, use the slow path with more allocations
-	if prefix.is_empty() && suffix.is_empty() {
-		// We know that the newly-aligned slice will contain all the values
-		ImageDataCow::Borrowed(bytes.align_to_mut::<u32>().1)
-	} else {
-		// XXX: Use `as_chunks` when it stabilizes.
-		let u32pixels_buffer =
-			bytes.chunks(4).map(|chunk| u32::from_ne_bytes(chunk.try_into().unwrap())).collect();
-		ImageDataCow::Owned(u32pixels_buffer)
+		// Check if `align_to` gave us the optimal result.
+		//
+		// If it didn't, use the slow path with more allocations
+		if prefix.is_empty() && suffix.is_empty() {
+			// We know that the newly-aligned slice will contain all the values
+			ImageDataCow::Borrowed(bytes.align_to_mut::<u32>().1)
+		} else {
+			// XXX: Use `as_chunks` when it stabilizes.
+			let u32pixels_buffer = bytes
+				.chunks(4)
+				.map(|chunk| u32::from_ne_bytes(chunk.try_into().unwrap()))
+				.collect();
+			ImageDataCow::Owned(u32pixels_buffer)
+		}
 	}
 }
 
@@ -479,7 +472,7 @@ impl<'clipboard> Get<'clipboard> {
 		clipboard_win::raw::get_vec(FORMAT, &mut data)
 			.map_err(|_| Error::unknown("failed to read clipboard image data"))?;
 
-		read_cf_dibv5(&data)
+		image_data::read_cf_dibv5(&data)
 	}
 }
 
@@ -548,7 +541,7 @@ impl<'clipboard> Set<'clipboard> {
 			)));
 		};
 
-		add_cf_dibv5(open_clipboard, image)
+		image_data::add_cf_dibv5(open_clipboard, image)
 	}
 }
 

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -83,8 +83,11 @@ mod image_data {
 		unsafe {
 			let data_ptr = global_lock(hdata)?;
 			let _unlock = ScopeGuard::new(|| {
-				if GlobalUnlock(hdata) == 0 {
-					log::error!("Failed calling GlobalUnlock when writing dibv5 data");
+				if GlobalUnlock(hdata) != 0 {
+					log::error!(
+						"Failed calling GlobalUnlock when writing dibv5 data: {}",
+						io::Error::last_os_error(),
+					);
 				}
 			});
 

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -110,7 +110,7 @@ mod image_data {
 
 	unsafe fn global_alloc(bytes: usize) -> Result<HGLOBAL, Error> {
 		let hdata = GlobalAlloc(GHND, bytes);
-		if hdata.is_null() {
+		if hdata == 0 {
 			Err(last_error("Could not allocate global memory object"))
 		} else {
 			Ok(hdata)
@@ -178,7 +178,7 @@ mod image_data {
 					biHeight: -h,
 					biBitCount: 32,
 					biPlanes: 1,
-					biCompression: BI_RGB,
+					biCompression: BI_RGB as u32,
 					biSizeImage: 0,
 					biXPelsPerMeter: 0,
 					biYPelsPerMeter: 0,

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -17,9 +17,9 @@ use std::{borrow::Cow, marker::PhantomData, thread, time::Duration};
 mod image_data {
 	use super::*;
 	use crate::common::ScopeGuard;
-	use std::{convert::TryInto, ffi::c_void, intrinsics::copy_nonoverlapping, mem::size_of};
+	use std::{convert::TryInto, ffi::c_void, io, mem::size_of, ptr::copy_nonoverlapping};
 	use windows_sys::Win32::{
-		Foundation::{GetLastError, HANDLE, HGLOBAL},
+		Foundation::{HANDLE, HGLOBAL},
 		Graphics::Gdi::{
 			CreateDIBitmap, DeleteObject, GetDC, GetDIBits, BITMAPINFO, BITMAPINFOHEADER,
 			BITMAPV5HEADER, BI_BITFIELDS, BI_RGB, CBM_INIT, DIB_RGB_COLORS, HBITMAP, HDC,
@@ -33,8 +33,8 @@ mod image_data {
 	};
 
 	fn last_error(message: &str) -> Error {
-		let code = unsafe { GetLastError() };
-		Error::unknown(format!("{} with error code {:x}", message, code))
+		let os_error = io::Error::last_os_error();
+		Error::unknown(format!("{}: {}", message, os_error))
 	}
 
 	pub fn add_cf_dibv5(_open_clipboard: OpenClipboard, image: ImageData) -> Result<(), Error> {

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -377,6 +377,28 @@ mod image_data {
 			ImageDataCow::Owned(u32pixels_buffer)
 		}
 	}
+
+	#[test]
+	fn conversion_between_win_and_rgba() {
+		const DATA: [u8; 16] =
+			[100, 100, 255, 100, 0, 0, 0, 255, 255, 100, 100, 255, 100, 255, 100, 100];
+
+		let mut data = DATA;
+		let _converted = unsafe { win_to_rgba(&mut data) };
+
+		let mut data = DATA;
+		let _converted = unsafe { rgba_to_win(&mut data) };
+
+		let mut data = DATA;
+		let _converted = unsafe { win_to_rgba(&mut data) };
+		let _converted = unsafe { rgba_to_win(&mut data) };
+		assert_eq!(data, DATA);
+
+		let mut data = DATA;
+		let _converted = unsafe { rgba_to_win(&mut data) };
+		let _converted = unsafe { win_to_rgba(&mut data) };
+		assert_eq!(data, DATA);
+	}
 }
 
 /// A shim clipboard type that can have operations performed with it, but
@@ -718,24 +740,4 @@ fn wrap_html(ctn: &str) -> String {
 		ctn,
 		c_end_frag,
 	)
-}
-
-#[cfg(all(test, feature = "image-data"))]
-mod tests {
-	use super::{rgba_to_win, win_to_rgba};
-
-	const DATA: [u8; 16] =
-		[100, 100, 255, 100, 0, 0, 0, 255, 255, 100, 100, 255, 100, 255, 100, 100];
-
-	#[test]
-	fn check_win_to_rgba_conversion() {
-		let mut data = DATA;
-		let _converted = unsafe { win_to_rgba(&mut data) };
-	}
-
-	#[test]
-	fn check_rgba_to_win_conversion() {
-		let mut data = DATA;
-		let _converted = unsafe { rgba_to_win(&mut data) };
-	}
 }

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -162,6 +162,11 @@ fn read_cf_dibv5(dibv5: &[u8]) -> Result<ImageData<'static>, Error> {
 	unsafe {
 		let image_bytes = dibv5.as_ptr().offset(pixel_data_start) as *const _;
 		let hdc = GetDC(HWND(std::ptr::null::<c_void>() as _));
+		if hdc.is_invalid() {
+			return Err(Error::Unknown {
+				description: "Failed to get the device context. GetDC returned null".into(),
+			});
+		}
 
 		let hbitmap = CreateDIBitmap(
 			hdc,


### PR DESCRIPTION
This PR does two things for Windows support:

1. Update clipboard-win to v5.0.0
   - I checked [changes in v5.0.0](https://github.com/DoumanAsh/clipboard-win/compare/44487b19cd12a9242f5b1991c088bf81c780f172...973219a363729dcaeb98ba74280f3543322f37d7) and the changes didn't affect any implementation in this crate
3. Replace `winapi` crate dependency with `windows-rs`
   - winapi is unmaintained. windows-rs is well-maintained by Microsoft officially
   - By this change, winapi can be removed completely from this crate
   - The replacement is somewhat mechanical translation from winapi to windows-rs. I read MSDN documents but my understanding of the Win32 APIs is not perfect. I'd like to have a detailed code review
   - Some constants used by this crate are not defined in windows-rs. I defined them directly in `platform/windows.rs`

I confirmed writing/reading clipboard with both text and image contents using `hello_world` and `set_image`/`get_image` examples on my Windows 10 machine.

With this PR, cargo dependencies will change to:

```console
> cargo tree --edges no-dev
arboard v3.3.0
├── clipboard-win v5.0.0
│   └── error-code v3.0.0
├── log v0.4.20
├── thiserror v1.0.35
│   └── thiserror-impl v1.0.35 (proc-macro)
│       ├── proc-macro2 v1.0.43
│       │   └── unicode-ident v1.0.4
│       ├── quote v1.0.21
│       │   └── proc-macro2 v1.0.43 (*)
│       └── syn v1.0.100
│           ├── proc-macro2 v1.0.43 (*)
│           ├── quote v1.0.21 (*)
│           └── unicode-ident v1.0.4
└── windows v0.52.0
    ├── windows-core v0.52.0
    │   └── windows-targets v0.52.0
    │       └── windows_x86_64_msvc v0.52.0
    └── windows-targets v0.52.0 (*)
```