### PR TITLE
Set custom timeout for x11 server connection.

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -51,7 +51,7 @@ pub enum Error {
 	#[error("The image or the text that was about the be transferred to/from the clipboard could not be converted to the appropriate format.")]
 	ConversionFailure,
 
-	/// X11 server connection timed out because it was unreachable.
+	/// X11 server connection timed out error.
 	///
 	/// This error is only relevant on X11 systems and is returned when the X11 server
 	/// could not be connected to in time.

--- a/src/common.rs
+++ b/src/common.rs
@@ -51,6 +51,13 @@ pub enum Error {
 	#[error("The image or the text that was about the be transferred to/from the clipboard could not be converted to the appropriate format.")]
 	ConversionFailure,
 
+	/// X11 server connection timed out because it was unreachable.
+	///
+	/// This error is only relevant on X11 systems and is returned when the X11 server
+	/// could not be connected to in time.
+	#[error("X11 server connection timed out because it was unreachable")]
+	X11ServerConnTimeout,
+
 	/// Any error that doesn't fit the other error types.
 	///
 	/// The `description` field is only meant to help the developer and should not be relied on as a
@@ -76,6 +83,7 @@ impl std::fmt::Debug for Error {
 			ClipboardNotSupported,
 			ClipboardOccupied,
 			ConversionFailure,
+			X11ServerConnTimeout,
 			Unknown { .. }
 		);
 		f.write_fmt(format_args!("{} - \"{}\"", name, self))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ and conditions of the chosen license apply to this file.
 */
 
 mod common;
-use std::borrow::Cow;
+use std::{borrow::Cow, time::Duration};
 
 pub use common::Error;
 #[cfg(feature = "image-data")]
@@ -65,6 +65,22 @@ pub struct Clipboard {
 }
 
 impl Clipboard {
+	#[cfg(all(
+		unix,
+		not(any(target_os = "macos", target_os = "android", target_os = "emscripten"))
+	))]
+	pub fn get_x11_server_conn_timeout() -> Duration {
+		platform::Clipboard::get_x11_server_conn_timeout()
+	}
+
+	#[cfg(all(
+		unix,
+		not(any(target_os = "macos", target_os = "android", target_os = "emscripten"))
+	))]
+	pub fn set_x11_server_conn_timeout(dur: Duration) {
+		platform::Clipboard::set_x11_server_conn_timeout(dur);
+	}
+
 	/// Creates an instance of the clipboard.
 	///
 	/// # Errors

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ and conditions of the chosen license apply to this file.
 */
 
 mod common;
-use std::{borrow::Cow, time::Duration};
+use std::borrow::Cow;
 
 pub use common::Error;
 #[cfg(feature = "image-data")]
@@ -65,20 +65,24 @@ pub struct Clipboard {
 }
 
 impl Clipboard {
+	/// Get the timeout for X11 server connection in milliseconds.
+	///
 	#[cfg(all(
 		unix,
 		not(any(target_os = "macos", target_os = "android", target_os = "emscripten"))
 	))]
-	pub fn get_x11_server_conn_timeout() -> Duration {
+	pub fn get_x11_server_conn_timeout() -> u64 {
 		platform::Clipboard::get_x11_server_conn_timeout()
 	}
 
+	/// Set the timeout for X11 server connection in milliseconds.
+	///
 	#[cfg(all(
 		unix,
 		not(any(target_os = "macos", target_os = "android", target_os = "emscripten"))
 	))]
-	pub fn set_x11_server_conn_timeout(dur: Duration) {
-		platform::Clipboard::set_x11_server_conn_timeout(dur);
+	pub fn set_x11_server_conn_timeout(msecs: u64) {
+		platform::Clipboard::set_x11_server_conn_timeout(msecs);
 	}
 
 	/// Creates an instance of the clipboard.

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, time::Duration};
+use std::borrow::Cow;
 
 #[cfg(feature = "wayland-data-control")]
 use log::{trace, warn};
@@ -76,13 +76,13 @@ pub(crate) enum Clipboard {
 
 impl Clipboard {
 	#[inline]
-	pub(crate) fn get_x11_server_conn_timeout() -> Duration {
-		x11::Clipboard::get_x11_server_conn_timeout()
+	pub(crate) fn get_x11_server_conn_timeout() -> u64 {
+		x11::Clipboard::get_server_conn_timeout_msecs()
 	}
 
 	#[inline]
-	pub(crate) fn set_x11_server_conn_timeout(dur: Duration) {
-		x11::Clipboard::set_x11_server_conn_timeout(dur);
+	pub(crate) fn set_x11_server_conn_timeout(msecs: u64) {
+		x11::Clipboard::set_server_conn_timeout_msecs(msecs);
 	}
 
 	pub(crate) fn new() -> Result<Self, Error> {

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -1,4 +1,4 @@
-use std::borrow::Cow;
+use std::{borrow::Cow, time::Duration};
 
 #[cfg(feature = "wayland-data-control")]
 use log::{trace, warn};
@@ -75,6 +75,16 @@ pub(crate) enum Clipboard {
 }
 
 impl Clipboard {
+	#[inline]
+	pub(crate) fn get_x11_server_conn_timeout() -> Duration {
+		x11::Clipboard::get_x11_server_conn_timeout()
+	}
+
+	#[inline]
+	pub(crate) fn set_x11_server_conn_timeout(dur: Duration) {
+		x11::Clipboard::set_x11_server_conn_timeout(dur);
+	}
+
 	pub(crate) fn new() -> Result<Self, Error> {
 		#[cfg(feature = "wayland-data-control")]
 		{

--- a/src/platform/linux/x11.rs
+++ b/src/platform/linux/x11.rs
@@ -17,7 +17,7 @@ use std::{
 	cell::RefCell,
 	collections::{hash_map::Entry, HashMap},
 	sync::{
-		atomic::{AtomicBool, Ordering, AtomicU64},
+		atomic::{AtomicBool, AtomicU64, Ordering},
 		mpsc, Arc,
 	},
 	thread::{self, JoinHandle},
@@ -142,15 +142,14 @@ impl XContext {
 			tx.send(RustConnection::connect(None)).ok(); // disregard error sending on channel as main thread has timed out.
 		});
 		let timeout_dur = Duration::from_millis(Clipboard::get_server_conn_timeout_msecs());
-		let patient_conn =
-			rx.recv_timeout(timeout_dur).map_err(|e| match e {
-				mpsc::RecvTimeoutError::Timeout => Error::X11ServerConnTimeout,
-				mpsc::RecvTimeoutError::Disconnected => Error::Unknown {
-					description: String::from(
-						"The channel to the X11 server connection thread was disconnected.",
-					),
-				},
-			})?;
+		let patient_conn = rx.recv_timeout(timeout_dur).map_err(|e| match e {
+			mpsc::RecvTimeoutError::Timeout => Error::X11ServerConnTimeout,
+			mpsc::RecvTimeoutError::Disconnected => Error::Unknown {
+				description: String::from(
+					"The channel to the X11 server connection thread was disconnected.",
+				),
+			},
+		})?;
 		let (conn, screen_num): (RustConnection, _) = patient_conn.map_err(into_unknown)?;
 
 		let screen = conn


### PR DESCRIPTION
1. Add an error type `X11ServerConnTimeout`.
2. Add apis of set and get conn timeout for x11.

SHORT_TIMEOUT_DUR may be not enough sometimes.

Retry and longer timeout may be required.