### PR TITLE
Add `SetExtLinux#wait_until`

### DIFF
--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -244,6 +244,9 @@ pub trait SetExtLinux: private::Sealed {
 	/// This is useful for short-lived programs so that it doesn't block until new contents on the clipboard
 	/// were added and will exit as so.
 	///
+	/// For X11, this will wait until it either had new contents available in the clipboard or if the
+	/// `deadline` was exceeded. This isn't available for Wayland and will not do anything.
+	///
 	/// Note: this will call [`wait()`][SetExtLinux::wait] if it wasn't previously set.
 	fn wait_until(self, deadline: Instant) -> Self;
 }

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -244,7 +244,7 @@ pub trait SetExtLinux: private::Sealed {
 	/// This is useful for short-lived programs so that it doesn't block until new contents on the clipboard
 	/// were added and will exit as so.
 	///
-	/// Note: this will call [`wait()`][SetExtLinux::wait].
+	/// Note: this will call [`wait()`][SetExtLinux::wait] if it wasn't previously set.
 	fn wait_until(self, deadline: Instant) -> Self;
 }
 

--- a/src/platform/linux/wayland.rs
+++ b/src/platform/linux/wayland.rs
@@ -10,7 +10,7 @@ use wl_clipboard_rs::{
 
 #[cfg(feature = "image-data")]
 use super::encode_as_png;
-use super::{into_unknown, LinuxClipboardKind};
+use super::{into_unknown, LinuxClipboardKind, WaitConfig};
 use crate::common::Error;
 #[cfg(feature = "image-data")]
 use crate::common::ImageData;
@@ -79,10 +79,14 @@ impl Clipboard {
 		&self,
 		text: Cow<'_, str>,
 		selection: LinuxClipboardKind,
-		wait: bool,
+		wait: WaitConfig,
 	) -> Result<(), Error> {
 		let mut opts = Options::new();
-		opts.foreground(wait);
+		opts.foreground(match wait {
+			WaitConfig::Forever => true,
+			_ => false,
+		});
+
 		opts.clipboard(selection.try_into()?);
 		let source = Source::Bytes(text.into_owned().into_bytes().into_boxed_slice());
 		opts.copy(source, MimeType::Text).map_err(|e| match e {
@@ -97,11 +101,15 @@ impl Clipboard {
 		html: Cow<'_, str>,
 		alt: Option<Cow<'_, str>>,
 		selection: LinuxClipboardKind,
-		wait: bool,
+		wait: WaitConfig,
 	) -> Result<(), Error> {
 		let html_mime = MimeType::Specific(String::from("text/html"));
 		let mut opts = Options::new();
-		opts.foreground(wait);
+		opts.foreground(match wait {
+			WaitConfig::Forever => true,
+			_ => false,
+		});
+
 		opts.clipboard(selection.try_into()?);
 		let html_source = Source::Bytes(html.into_owned().into_bytes().into_boxed_slice());
 		match alt {
@@ -163,11 +171,15 @@ impl Clipboard {
 		&mut self,
 		image: ImageData,
 		selection: LinuxClipboardKind,
-		wait: bool,
+		wait: WaitConfig,
 	) -> Result<(), Error> {
 		let image = encode_as_png(&image)?;
 		let mut opts = Options::new();
-		opts.foreground(wait);
+		opts.foreground(match wait {
+			WaitConfig::Forever => true,
+			_ => false,
+		});
+
 		opts.clipboard(selection.try_into()?);
 		let source = Source::Bytes(image.into());
 		opts.copy(source, MimeType::Specific(MIME_PNG.into())).map_err(into_unknown)?;

--- a/src/platform/linux/wayland.rs
+++ b/src/platform/linux/wayland.rs
@@ -1,5 +1,4 @@
 use std::borrow::Cow;
-use std::convert::TryInto;
 use std::io::Read;
 
 use wl_clipboard_rs::{
@@ -82,11 +81,7 @@ impl Clipboard {
 		wait: WaitConfig,
 	) -> Result<(), Error> {
 		let mut opts = Options::new();
-		opts.foreground(match wait {
-			WaitConfig::Forever => true,
-			_ => false,
-		});
-
+		opts.foreground(matches!(wait, WaitConfig::Forever));
 		opts.clipboard(selection.try_into()?);
 		let source = Source::Bytes(text.into_owned().into_bytes().into_boxed_slice());
 		opts.copy(source, MimeType::Text).map_err(|e| match e {
@@ -105,11 +100,7 @@ impl Clipboard {
 	) -> Result<(), Error> {
 		let html_mime = MimeType::Specific(String::from("text/html"));
 		let mut opts = Options::new();
-		opts.foreground(match wait {
-			WaitConfig::Forever => true,
-			_ => false,
-		});
-
+		opts.foreground(matches!(wait, WaitConfig::Forever));
 		opts.clipboard(selection.try_into()?);
 		let html_source = Source::Bytes(html.into_owned().into_bytes().into_boxed_slice());
 		match alt {
@@ -175,11 +166,7 @@ impl Clipboard {
 	) -> Result<(), Error> {
 		let image = encode_as_png(&image)?;
 		let mut opts = Options::new();
-		opts.foreground(match wait {
-			WaitConfig::Forever => true,
-			_ => false,
-		});
-
+		opts.foreground(matches!(wait, WaitConfig::Forever));
 		opts.clipboard(selection.try_into()?);
 		let source = Source::Bytes(image.into());
 		opts.copy(source, MimeType::Specific(MIME_PNG.into())).map_err(into_unknown)?;

--- a/src/platform/linux/x11.rs
+++ b/src/platform/linux/x11.rs
@@ -45,7 +45,7 @@ use x11rb::{
 
 #[cfg(feature = "image-data")]
 use super::encode_as_png;
-use super::{into_unknown, LinuxClipboardKind};
+use super::{into_unknown, LinuxClipboardKind, WaitConfig};
 #[cfg(feature = "image-data")]
 use crate::ImageData;
 use crate::{common::ScopeGuard, Error};
@@ -203,20 +203,6 @@ enum ReadSelNotifyResult {
 	GotData(Vec<u8>),
 	IncrStarted,
 	EventNotRecognized,
-}
-
-/// Configuration on how long to wait for a new X11 copy event is emitted.
-#[derive(Default)]
-pub enum WaitConfig {
-	/// Waits until the given [`Instant`] has reached.
-	Until(Instant),
-
-	/// Waits forever until a new event is reached.
-	Forever,
-
-	/// It shouldn't wait.
-	#[default]
-	None,
 }
 
 impl Inner {


### PR DESCRIPTION
Hello :wave:!

I added a `wait_until` method on [`SetExtLinux`](https://github.com/1Password/arboard/blob/77e0e078eb460ac2fa0eda96124163c11ef6b2d1/src/platform/linux/mod.rs#L181) for X11 to wait until a deadline was exceeded so that:

* You wouldn't need a daemon process to call `wait` on.
* Easier for CLI programs who don't want to infinitely loop / wait for new contents to be replaced & want to finish quickly.

This does report the following log when used:
```sh
2024-02-22T18:28:30.515424Z  WARN arboard::platform::linux::x11: Could not hand the clipboard contents over to the clipboard manager. The request timed out.
```

since `result.timed_out` is used and I'm not too sure what to do in this case:
https://github.com/1Password/arboard/blob/77e0e078eb460ac2fa0eda96124163c11ef6b2d1/src/platform/linux/x11.rs#L711-L715