### PR TITLE
Fix build error on Windows by making `OpenClipboard` public

### DIFF
--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -419,7 +419,7 @@ impl Drop for Clipboard {
 	fn drop(&mut self) {}
 }
 
-struct OpenClipboard<'clipboard> {
+pub struct OpenClipboard<'clipboard> {
 	_inner: clipboard_win::Clipboard,
 	// The Windows clipboard can not be sent between threads once
 	// open.


### PR DESCRIPTION
Ref issue #136.

Fixes build error on Windows.
Might want another solution for this that doesn't directly expose the `OpenClipboard` type.