### PR TITLE
Fix Windows image function visibility causing build issues

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   rustfmt:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
@@ -93,7 +93,7 @@ jobs:
         run: cargo miri test windows --features image-data
 
   semver:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
     - name: Check semver

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,3 +91,10 @@ jobs:
 
       - name: Check soundness
         run: cargo miri test windows --features image-data
+
+  semver:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v4
+    - name: Check semver
+      uses: obi1kenobi/cargo-semver-checks-action@v2

--- a/src/common.rs
+++ b/src/common.rs
@@ -167,6 +167,9 @@ impl<F: FnOnce()> Drop for ScopeGuard<F> {
 
 /// Common trait for sealing platform extension traits.
 pub(crate) mod private {
+	// This is currently unused on macOS, so silence the warning which appears
+	// since there's no extension traits making use of this trait sealing structure.
+	#[cfg_attr(target_vendor = "apple", allow(unreachable_pub))]
 	pub trait Sealed {}
 
 	impl Sealed for crate::Get<'_> {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ The project to which this file belongs is licensed under either of
 the Apache 2.0 or the MIT license at the licensee's choice. The terms
 and conditions of the chosen license apply to this file.
 */
+#![warn(unreachable_pub)]
 
 mod common;
 use std::borrow::Cow;

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -37,7 +37,10 @@ mod image_data {
 		Error::unknown(format!("{}: {}", message, os_error))
 	}
 
-	pub fn add_cf_dibv5(_open_clipboard: OpenClipboard, image: ImageData) -> Result<(), Error> {
+	pub(super) fn add_cf_dibv5(
+		_open_clipboard: OpenClipboard,
+		image: ImageData,
+	) -> Result<(), Error> {
 		// This constant is missing in windows-rs
 		// https://github.com/microsoft/windows-rs/issues/2711
 		#[allow(non_upper_case_globals)]
@@ -137,7 +140,7 @@ mod image_data {
 		}
 	}
 
-	pub fn read_cf_dibv5(dibv5: &[u8]) -> Result<ImageData<'static>, Error> {
+	pub(super) fn read_cf_dibv5(dibv5: &[u8]) -> Result<ImageData<'static>, Error> {
 		// The DIBV5 format is a BITMAPV5HEADER followed by the pixel data according to
 		// https://docs.microsoft.com/en-us/windows/win32/dataxchg/standard-clipboard-formats
 


### PR DESCRIPTION
This MR follows up to #123 fixing the visibility of `read_cf_dibv5` and `add_cf_dibv5` inside `windows::image_data`. Neither of these functions are used outside of the Windows module so they should not have been marked `pub` in the first place. This is my bad for not catching it during review. However I am still unsure how these are causing hard compilation failures.

In addition, this PR turns on Rust's `unreachable_pub` lint as a warning CI can deny, which would have caught this on any Rust version. Finally, it also adds `cargo-semver-checks` to CI as an extra precaution and something to help me in the future.

Closes #136 