### PR TITLE
Bump MSRV to 1.67.1 and fix CI didn't check MSRV

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: stable
+          toolchain: ${{ matrix.rust_version }}
           components: clippy
       - uses: actions/checkout@v4
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
         os: [macos-latest, windows-latest, ubuntu-latest]
         # Latest stable and MSRV. We only run checks with all features enabled
         # for the MSRV build to keep CI fast, since other configurations should also work.
-        rust_version: [stable, "1.61"]
+        rust_version: [stable, "1.67.1"]
     steps:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 keywords = ["clipboard", "image"]
 edition = "2021"
-rust-version = "1.61"
+rust-version = "1.67.1"
 
 [features]
 default = ["image-data"]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Latest version](https://img.shields.io/crates/v/arboard?color=mediumvioletred)](https://crates.io/crates/arboard)
 [![Documentation](https://docs.rs/arboard/badge.svg)](https://docs.rs/arboard)
-![MSRV](https://img.shields.io/badge/rustc-1.61+-blue.svg)
+![MSRV](https://img.shields.io/badge/rustc-1.67.1+-blue.svg)
 
 ## General
 


### PR DESCRIPTION
Hi,

I investigated why #136 was not caught by CI. And I found that CI workflows for Rust 1.61 was actually using the latest stable toolchain.

This PR fixes the issue. I could confirm 1.61 was used properly on my fork.

```
info: syncing channel updates for '1.61-x86_64-unknown-linux-gnu'
info: latest update on 2022-05-19, rust version 1.61.0 (fe5b13d68 2022-05-18)
```

https://github.com/rhysd/arboard/actions/runs/8135373857/job/22229818914

Please note that CI will break after merging this PR. This is because `wayland-backend` crate requires Rust 1.65 or later.

```
error: package `wayland-backend v0.3.2` cannot be built because it requires rustc 1.65 or newer, while the currently active rustc version is 1.61.0
```

I didn't bump the MSRV of this crate in this PR because I'm not understanding the process. (If you prefer bumping MSRV in this PR, please let me know. I'll include the changes.)