### PR TITLE
Increase version of clipboard-win used by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,9 +103,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clipboard-win"
-version = "5.0.0"
+version = "5.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c57002a5d9be777c1ef967e33674dac9ebd310d8893e4e3437b14d5f0f6372cc"
+checksum = "79f4473f5144e20d9aceaf2972478f06ddf687831eafeeb434fbaf0acc4144ad"
 dependencies = [
  "error-code",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ windows-sys = { version = "0.48.0", optional = true, features = [
     "Win32_System_Memory",
     "Win32_System_Ole",
 ]}
-clipboard-win = "5.0.0"
+clipboard-win = "5.3.1"
 log = "0.4"
 
 [target.'cfg(target_os = "macos")'.dependencies]


### PR DESCRIPTION
This PR increases the minimum version of `clipboard-win` we want by default. This does not require downstream users to use the same version though, because of SemVer. The vulnerability is unlikely enough to be a problem that its not worth causing issues with declaring SemVer ranges in our `Cargo.toml`.

Closes #145 