### PR TITLE
Add Set::exclude_from_history on linux by setting x-kde-passwordManagerHint

### DIFF
--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -8,6 +8,10 @@ use percent_encoding::percent_decode_str;
 use crate::ImageData;
 use crate::{common::private, Error};
 
+// Magic strings used in `Set::exclude_from_history()` on linux
+const KDE_EXCLUSION_MIME: &str = "x-kde-passwordManagerHint";
+const KDE_EXCLUSION_HINT: &[u8] = b"secret";
+
 mod x11;
 
 #[cfg(feature = "wayland-data-control")]
@@ -184,38 +188,56 @@ pub(crate) struct Set<'clipboard> {
 	clipboard: &'clipboard mut Clipboard,
 	wait: WaitConfig,
 	selection: LinuxClipboardKind,
+	exclude_from_history: bool,
 }
 
 impl<'clipboard> Set<'clipboard> {
 	pub(crate) fn new(clipboard: &'clipboard mut Clipboard) -> Self {
-		Self { clipboard, wait: WaitConfig::default(), selection: LinuxClipboardKind::Clipboard }
+		Self {
+			clipboard,
+			wait: WaitConfig::default(),
+			selection: LinuxClipboardKind::Clipboard,
+			exclude_from_history: false,
+		}
 	}
 
 	pub(crate) fn text(self, text: Cow<'_, str>) -> Result<(), Error> {
 		match self.clipboard {
-			Clipboard::X11(clipboard) => clipboard.set_text(text, self.selection, self.wait),
+			Clipboard::X11(clipboard) => {
+				clipboard.set_text(text, self.selection, self.wait, self.exclude_from_history)
+			}
 
 			#[cfg(feature = "wayland-data-control")]
-			Clipboard::WlDataControl(clipboard) => clipboard.set_text(text, self.selection, self.wait),
+			Clipboard::WlDataControl(clipboard) => {
+				clipboard.set_text(text, self.selection, self.wait, self.exclude_from_history)
+			}
 		}
 	}
 
 	pub(crate) fn html(self, html: Cow<'_, str>, alt: Option<Cow<'_, str>>) -> Result<(), Error> {
 		match self.clipboard {
-			Clipboard::X11(clipboard) => clipboard.set_html(html, alt, self.selection, self.wait),
+			Clipboard::X11(clipboard) => {
+				clipboard.set_html(html, alt, self.selection, self.wait, self.exclude_from_history)
+			}
 
 			#[cfg(feature = "wayland-data-control")]
-			Clipboard::WlDataControl(clipboard) => clipboard.set_html(html, alt, self.selection, self.wait),
+			Clipboard::WlDataControl(clipboard) => {
+				clipboard.set_html(html, alt, self.selection, self.wait, self.exclude_from_history)
+			}
 		}
 	}
 
 	#[cfg(feature = "image-data")]
 	pub(crate) fn image(self, image: ImageData<'_>) -> Result<(), Error> {
 		match self.clipboard {
-			Clipboard::X11(clipboard) => clipboard.set_image(image, self.selection, self.wait),
+			Clipboard::X11(clipboard) => {
+				clipboard.set_image(image, self.selection, self.wait, self.exclude_from_history)
+			}
 
 			#[cfg(feature = "wayland-data-control")]
-			Clipboard::WlDataControl(clipboard) => clipboard.set_image(image, self.selection, self.wait),
+			Clipboard::WlDataControl(clipboard) => {
+				clipboard.set_image(image, self.selection, self.wait, self.exclude_from_history)
+			}
 		}
 	}
 }
@@ -280,6 +302,13 @@ pub trait SetExtLinux: private::Sealed {
 	/// # }
 	/// ```
 	fn clipboard(self, selection: LinuxClipboardKind) -> Self;
+
+	/// Excludes the data which will be set on the clipboard from being added to
+	/// the desktop clipboard managers' histories by adding the MIME-Type `x-kde-passwordMangagerHint`
+	/// to the clipboard's selection data.
+	///
+	/// This is the most widely adopted convention on Linux.
+	fn exclude_from_history(self) -> Self;
 }
 
 impl SetExtLinux for crate::Set<'_> {
@@ -295,6 +324,11 @@ impl SetExtLinux for crate::Set<'_> {
 
 	fn wait_until(mut self, deadline: Instant) -> Self {
 		self.platform.wait = WaitConfig::Until(deadline);
+		self
+	}
+
+	fn exclude_from_history(mut self) -> Self {
+		self.platform.exclude_from_history = true;
 		self
 	}
 }
@@ -357,7 +391,7 @@ mod tests {
 	fn test_decoding_uri_list() {
 		// Test that paths_from_uri_list correctly decodes
 		// differents percent encoded characters
-		let file_list = vec![
+		let file_list = [
 			"file:///tmp/bar.log",
 			"file:///tmp/test%5C.txt",
 			"file:///tmp/foo%3F.png",

--- a/src/platform/linux/wayland.rs
+++ b/src/platform/linux/wayland.rs
@@ -114,8 +114,7 @@ impl Clipboard {
 		opts.copy_multi(sources).map_err(|e| match e {
 			CopyError::PrimarySelectionUnsupported => Error::ClipboardNotSupported,
 			other => into_unknown(other),
-		})?;
-		Ok(())
+		})
 	}
 
 	pub(crate) fn get_html(&mut self, selection: LinuxClipboardKind) -> Result<String, Error> {
@@ -159,8 +158,7 @@ impl Clipboard {
 		opts.copy_multi(sources).map_err(|e| match e {
 			CopyError::PrimarySelectionUnsupported => Error::ClipboardNotSupported,
 			other => into_unknown(other),
-		})?;
-		Ok(())
+		})
 	}
 
 	#[cfg(feature = "image-data")]


### PR DESCRIPTION
Fixes #129
Implements the Set::exclude_from_history method for linux.

I tested this on Plasma Wayland (they implement data control protocol) and X11 using this short rust program:
```rust
use arboard::Clipboard;
#[cfg(target_os = "linux")]
use arboard::SetExtLinux;
use std::{thread, time};

fn main() {
    let ten_millis = time::Duration::from_secs(10);
    let mut clipboard = Clipboard::new().unwrap();

    let d = clipboard.set().exclude_from_history().text("secretext");
    println!("hidden");
    thread::sleep(ten_millis);
    let d = clipboard.set().text("notsecrettext");
    println!("Not hidden");
    thread::sleep(ten_millis);
}
```
It did not display the `secretext` when pressing `SUPER+V`(opens klipper) but it did display the `notsecrettext` after 10 seconds, so it works as intended.

Gnome doesn't implement the data control protocol, but testing this change with `wl-paste -l`(probably falling back to the xserver clipboard stuff) seemed to work as well.

In contrast, using a gnome-shell-extension that hooks the the [get_mimetypes-method](https://gjs-docs.gnome.org/st14~14/st.clipboard#method-get_mimetypes) from within the compositor for determinig the clipboard-data-content didn't seem to work properly.
With KeepassXC, which is just using Qt's-functions for handling the clipboard, this function behaved as expected on gnome from what I can tell.

I believe there is some deeper issue with the way gnome handles the clipboard in general, but I was not able to track down the specific difference between how Qt and arboard register their clipboard content to the compositor yet.

Thanks for reviewing this and have a nice Day!