### PR TITLE
Add Get::html on macOS (unimplemented on others)

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -176,7 +176,7 @@ impl<F: FnOnce()> Drop for ScopeGuard<F> {
 pub(crate) mod private {
 	// This is currently unused on macOS, so silence the warning which appears
 	// since there's no extension traits making use of this trait sealing structure.
-	#[cfg_attr(target_vendor = "apple", allow(unreachable_pub))]
+	#[cfg_attr(target_vendor = "apple", allow(unreachable_pub, dead_code))]
 	pub trait Sealed {}
 
 	impl Sealed for crate::Get<'_> {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -179,6 +179,11 @@ impl Get<'_> {
 		self.platform.text()
 	}
 
+	/// Completes the "get" operation by fetching HTML from the clipboard.
+	pub fn html(self) -> Result<String, Error> {
+		self.platform.html()
+	}
+
 	/// Completes the "get" operation by fetching image data from the clipboard and returning the
 	/// decoded pixels.
 	///

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -114,6 +114,10 @@ impl<'clipboard> Get<'clipboard> {
 		}
 	}
 
+	pub(crate) fn html(self) -> Result<String, Error> {
+		unimplemented!()
+	}
+
 	#[cfg(feature = "image-data")]
 	pub(crate) fn image(self) -> Result<ImageData<'static>, Error> {
 		match self.clipboard {

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -567,6 +567,10 @@ impl<'clipboard> Get<'clipboard> {
 		String::from_utf16(&out[..bytes_read]).map_err(|_| Error::ConversionFailure)
 	}
 
+	pub(crate) fn html(self) -> Result<String, Error> {
+		unimplemented!()
+	}
+
 	#[cfg(feature = "image-data")]
 	pub(crate) fn image(self) -> Result<ImageData<'static>, Error> {
 		const FORMAT: u32 = clipboard_win::formats::CF_DIBV5;


### PR DESCRIPTION
So this is half-baked since it panics on non-macOS platforms, but I can work on finishing it up if that's something y'all are willing to bear the burden of maintaining long-term.

If not, it'll just live in a fork of mine! Let me know!

(also just noticing https://github.com/1Password/arboard/pull/130 now)