### PR TITLE
Add support for excluding macos clipboard items from history

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -174,8 +174,6 @@ impl<F: FnOnce()> Drop for ScopeGuard<F> {
 
 /// Common trait for sealing platform extension traits.
 pub(crate) mod private {
-	// This is currently unused on macOS, so silence the warning which appears
-	// since there's no extension traits making use of this trait sealing structure.
 	pub trait Sealed {}
 
 	impl Sealed for crate::Get<'_> {}

--- a/src/common.rs
+++ b/src/common.rs
@@ -176,7 +176,6 @@ impl<F: FnOnce()> Drop for ScopeGuard<F> {
 pub(crate) mod private {
 	// This is currently unused on macOS, so silence the warning which appears
 	// since there's no extension traits making use of this trait sealing structure.
-	#[cfg_attr(target_vendor = "apple", allow(unreachable_pub))]
 	pub trait Sealed {}
 
 	impl Sealed for crate::Get<'_> {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,9 @@ pub use platform::{ClearExtLinux, GetExtLinux, LinuxClipboardKind, SetExtLinux};
 #[cfg(windows)]
 pub use platform::SetExtWindows;
 
+#[cfg(target_os = "macos")]
+pub use platform::SetExtOsx;
+
 /// The OS independent struct for accessing the clipboard.
 ///
 /// Any number of `Clipboard` instances are allowed to exist at a single point in time. Note however

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@ pub use platform::{ClearExtLinux, GetExtLinux, LinuxClipboardKind, SetExtLinux};
 pub use platform::SetExtWindows;
 
 #[cfg(target_os = "macos")]
-pub use platform::SetExtOsx;
+pub use platform::SetExtApple;
 
 /// The OS independent struct for accessing the clipboard.
 ///

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -14,4 +14,4 @@ pub use windows::*;
 #[cfg(target_os = "macos")]
 mod osx;
 #[cfg(target_os = "macos")]
-pub(crate) use osx::*;
+pub use osx::*;

--- a/src/platform/osx.rs
+++ b/src/platform/osx.rs
@@ -337,7 +337,7 @@ fn add_clipboard_exclusions(clipboard: &mut Clipboard, exclude_from_history: boo
 	// On Mac there isn't an official standard for excluding data from clipboard, however
 	// there is an unofficial standard which is to set `org.nspasteboard.ConcealedType`.
 	//
-	// https://nspasteboard.org/
+	// See http://nspasteboard.org/ for details about the community standard.
 	if exclude_from_history {
 		unsafe {
 			clipboard
@@ -347,16 +347,16 @@ fn add_clipboard_exclusions(clipboard: &mut Clipboard, exclude_from_history: boo
 	}
 }
 
-/// OS X-specific extensions to the [`Set`](crate::Set) builder.
-pub trait SetExtOsx: private::Sealed {
+/// Apple-specific extensions to the [`Set`](crate::Set) builder.
+pub trait SetExtApple: private::Sealed {
 	/// Excludes the data which will be set on the clipboard from being added to
 	/// third party clipboard history software.
 	///
-	/// http://nspasteboard.org/
+	/// See http://nspasteboard.org/ for details about the community standard.
 	fn exclude_from_history(self) -> Self;
 }
 
-impl SetExtOsx for crate::Set<'_> {
+impl SetExtApple for crate::Set<'_> {
 	fn exclude_from_history(mut self) -> Self {
 		self.platform.exclude_from_history = true;
 		self

--- a/src/platform/osx.rs
+++ b/src/platform/osx.rs
@@ -8,9 +8,9 @@ the Apache 2.0 or the MIT license at the licensee's choice. The terms
 and conditions of the chosen license apply to this file.
 */
 
-use crate::common::Error;
 #[cfg(feature = "image-data")]
 use crate::common::ImageData;
+use crate::common::{private, Error};
 use objc2::{
 	msg_send_id,
 	rc::{autoreleasepool, Id},
@@ -18,7 +18,7 @@ use objc2::{
 	ClassType,
 };
 use objc2_app_kit::{NSPasteboard, NSPasteboardTypeHTML, NSPasteboardTypeString};
-use objc2_foundation::{NSArray, NSString};
+use objc2_foundation::{ns_string, NSArray, NSString};
 use std::{
 	borrow::Cow,
 	panic::{RefUnwindSafe, UnwindSafe},
@@ -235,11 +235,12 @@ impl<'clipboard> Get<'clipboard> {
 
 pub(crate) struct Set<'clipboard> {
 	clipboard: &'clipboard mut Clipboard,
+	exclude_from_history: bool,
 }
 
 impl<'clipboard> Set<'clipboard> {
 	pub(crate) fn new(clipboard: &'clipboard mut Clipboard) -> Self {
-		Self { clipboard }
+		Self { clipboard, exclude_from_history: false }
 	}
 
 	pub(crate) fn text(self, data: Cow<'_, str>) -> Result<(), Error> {
@@ -248,6 +249,9 @@ impl<'clipboard> Set<'clipboard> {
 		let string_array =
 			NSArray::from_vec(vec![ProtocolObject::from_id(NSString::from_str(&data))]);
 		let success = unsafe { self.clipboard.pasteboard.writeObjects(&string_array) };
+
+		add_clipboard_exclusions(self.clipboard, self.exclude_from_history);
+
 		if success {
 			Ok(())
 		} else {
@@ -279,6 +283,9 @@ impl<'clipboard> Set<'clipboard> {
 				};
 			}
 		}
+
+		add_clipboard_exclusions(self.clipboard, self.exclude_from_history);
+
 		if success {
 			Ok(())
 		} else {
@@ -296,6 +303,9 @@ impl<'clipboard> Set<'clipboard> {
 
 		let image_array = NSArray::from_vec(vec![ProtocolObject::from_id(image)]);
 		let success = unsafe { self.clipboard.pasteboard.writeObjects(&image_array) };
+
+		add_clipboard_exclusions(self.clipboard, self.exclude_from_history);
+
 		if success {
 			Ok(())
 		} else {
@@ -320,5 +330,35 @@ impl<'clipboard> Clear<'clipboard> {
 	pub(crate) fn clear(self) -> Result<(), Error> {
 		self.clipboard.clear();
 		Ok(())
+	}
+}
+
+fn add_clipboard_exclusions(clipboard: &mut Clipboard, exclude_from_history: bool) {
+	// On Mac there isn't an official standard for excluding data from clipboard, however
+	// there is an unofficial standard which is to set `org.nspasteboard.ConcealedType`.
+	//
+	// https://nspasteboard.org/
+	if exclude_from_history {
+		unsafe {
+			clipboard
+				.pasteboard
+				.setString_forType(ns_string!(""), ns_string!("org.nspasteboard.ConcealedType"));
+		}
+	}
+}
+
+/// OS X-specific extensions to the [`Set`](crate::Set) builder.
+pub trait SetExtOsx: private::Sealed {
+	/// Excludes the data which will be set on the clipboard from being added to
+	/// third party clipboard history software.
+	///
+	/// http://nspasteboard.org/
+	fn exclude_from_history(self) -> Self;
+}
+
+impl SetExtOsx for crate::Set<'_> {
+	fn exclude_from_history(mut self) -> Self {
+		self.platform.exclude_from_history = true;
+		self
 	}
 }


### PR DESCRIPTION
This follows the Windows strategy of introducing a Set Extension for excluding items from history in MacOS. It's implemented mostly the same way with every set action calling a `add_clipboard_exclusions` function.

As there isn't technically an official standard it uses the community standard of setting `org.nspasteboard.ConcealedType` from http://nspasteboard.org/. I've manually tested this using the Maccy clipboard manager and with `exclude_history` items are no longer tracked.

I was a bit uncertain about the naming of the new trait as it could also be called `SetExtMac` but I decided to follow the filename.