### PR TITLE
Implement Get::html() for all platforms

### DIFF
--- a/examples/set_get_html.rs
+++ b/examples/set_get_html.rs
@@ -15,4 +15,7 @@ consectetur adipiscing elit."#;
 
 	ctx.set_html(html, Some(alt_text)).unwrap();
 	thread::sleep(Duration::from_secs(5));
+	
+	let success = ctx.get().html().unwrap() == html;
+	println!("Set and Get html operations were successful: {success}");
 }

--- a/examples/set_get_html.rs
+++ b/examples/set_get_html.rs
@@ -15,7 +15,7 @@ consectetur adipiscing elit."#;
 
 	ctx.set_html(html, Some(alt_text)).unwrap();
 	thread::sleep(Duration::from_secs(5));
-	
+
 	let success = ctx.get().html().unwrap() == html;
 	println!("Set and Get html operations were successful: {success}");
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -327,6 +327,15 @@ mod tests {
 			ctx.set_html(html, Some(alt_text)).unwrap();
 			assert_eq!(ctx.get_text().unwrap(), alt_text);
 		}
+		{
+			let mut ctx = Clipboard::new().unwrap();
+
+			let html = "<b>hello</b> <i>world</i>!";
+
+			ctx.set().html(html, None).unwrap();
+
+			assert_eq!(ctx.get().html().unwrap(), html);
+		}
 		#[cfg(feature = "image-data")]
 		{
 			let mut ctx = Clipboard::new().unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,6 +192,11 @@ impl Get<'_> {
 	pub fn image(self) -> Result<ImageData<'static>, Error> {
 		self.platform.image()
 	}
+
+	/// Completes the "get" operation by fetching HTML from the clipboard.
+	pub fn html(self) -> Result<String, Error> {
+		self.platform.html()
+	}
 }
 
 /// A builder for an operation that sets a value to the clipboard.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -334,7 +334,16 @@ mod tests {
 
 			ctx.set().html(html, None).unwrap();
 
-			assert_eq!(ctx.get().html().unwrap(), html);
+			if cfg!(target_os = "macos") {
+				// Copying HTML on macOS adds wrapper content to work around
+				// historical platform bugs. We control this wrapper, so we are
+				// able to check that the full user data still appears and at what
+				// position in the final copy contents.
+				let content = ctx.get().html().unwrap();
+				assert!(content.ends_with(&format!("{html}</body></html>")));
+			} else {
+				assert_eq!(ctx.get().html().unwrap(), html);
+			}
 		}
 		#[cfg(feature = "image-data")]
 		{

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -128,7 +128,7 @@ impl<'clipboard> Get<'clipboard> {
 			Clipboard::X11(clipboard) => clipboard.get_html(self.selection),
 			#[cfg(feature = "wayland-data-control")]
 			Clipboard::WlDataControl(clipboard) => clipboard.get_html(self.selection),
-		}	
+		}
 	}
 }
 

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -122,6 +122,14 @@ impl<'clipboard> Get<'clipboard> {
 			Clipboard::WlDataControl(clipboard) => clipboard.get_image(self.selection),
 		}
 	}
+
+	pub(crate) fn html(self) -> Result<String, Error> {
+		match self.clipboard {
+			Clipboard::X11(clipboard) => clipboard.get_html(self.selection),
+			#[cfg(feature = "wayland-data-control")]
+			Clipboard::WlDataControl(clipboard) => clipboard.get_html(self.selection),
+		}	
+	}
 }
 
 /// Linux-specific extensions to the [`Get`](super::Get) builder.

--- a/src/platform/linux/wayland.rs
+++ b/src/platform/linux/wayland.rs
@@ -53,7 +53,11 @@ impl Clipboard {
 		Ok(Self {})
 	}
 
-	fn string_for_mime(&mut self, selection: LinuxClipboardKind, mime: paste::MimeType) -> Result<String, Error> {
+	fn string_for_mime(
+		&mut self,
+		selection: LinuxClipboardKind,
+		mime: paste::MimeType,
+	) -> Result<String, Error> {
 		let result = get_contents(selection.try_into()?, Seat::Unspecified, mime);
 		match result {
 			Ok((mut pipe, _)) => {

--- a/src/platform/linux/x11.rs
+++ b/src/platform/linux/x11.rs
@@ -885,6 +885,12 @@ impl Clipboard {
 		self.inner.write(data, selection, wait)
 	}
 
+	pub(crate) fn get_html(&self, selection: LinuxClipboardKind) -> Result<String> {
+		let formats = [self.inner.atoms.HTML];
+		let result = self.inner.read(&formats, selection)?;
+		String::from_utf8(result.bytes).map_err(|_| Error::ConversionFailure)
+	}
+
 	pub(crate) fn set_html(
 		&self,
 		html: Cow<'_, str>,

--- a/src/platform/osx.rs
+++ b/src/platform/osx.rs
@@ -128,12 +128,9 @@ impl Clipboard {
 			// XXX: We explicitly use `pasteboardItems` and not `stringForType` since the latter will concat
 			// multiple strings, if present, into one and return it instead of reading just the first which is `arboard`'s
 			// historical behavior.
-			let contents =
-				unsafe { self.pasteboard.pasteboardItems() }.ok_or_else(|| {
-					Error::Unknown {
-						description: String::from("NSPasteboard#pasteboardItems errored"),
-					}
-				})?;
+			let contents = unsafe { self.pasteboard.pasteboardItems() }.ok_or_else(|| {
+				Error::Unknown { description: String::from("NSPasteboard#pasteboardItems errored") }
+			})?;
 
 			for item in contents {
 				if let Some(string) = unsafe { item.stringForType(type) } {

--- a/src/platform/osx.rs
+++ b/src/platform/osx.rs
@@ -121,7 +121,7 @@ impl Clipboard {
 		unsafe { self.pasteboard.clearContents() };
 	}
 
-	fn string_from_type(&self, type: &'static NSString) -> Result<String, Error> {
+	fn string_from_type(&self, type_: &'static NSString) -> Result<String, Error> {
 		// XXX: There does not appear to be an alternative for obtaining text without the need for
 		// autorelease behavior.
 		autoreleasepool(|_| {
@@ -133,7 +133,7 @@ impl Clipboard {
 			})?;
 
 			for item in contents {
-				if let Some(string) = unsafe { item.stringForType(type) } {
+				if let Some(string) = unsafe { item.stringForType(type_) } {
 					return Ok(string.to_string());
 				}
 			}
@@ -203,11 +203,11 @@ impl<'clipboard> Get<'clipboard> {
 	}
 
 	pub(crate) fn text(self) -> Result<String, Error> {
-		self.clipboard.string_from_type(NSPasteboardTypeString)
+		unsafe { self.clipboard.string_from_type(NSPasteboardTypeString) }
 	}
 
 	pub(crate) fn html(self) -> Result<String, Error> {
-		self.clipboard.string_from_type(NSPasteboardTypeHTML)
+		unsafe { self.clipboard.string_from_type(NSPasteboardTypeHTML) }
 	}
 
 	#[cfg(feature = "image-data")]

--- a/src/platform/osx.rs
+++ b/src/platform/osx.rs
@@ -207,7 +207,8 @@ impl<'clipboard> Get<'clipboard> {
 	}
 
 	pub(crate) fn html(self) -> Result<String, Error> {
-		unsafe { self.clipboard.string_from_type(NSPasteboardTypeHTML) }
+		let html = unsafe { self.clipboard.string_from_type(NSPasteboardTypeHTML) }?;
+		extract_html(html).ok_or(Error::ConversionFailure)
 	}
 
 	#[cfg(feature = "image-data")]
@@ -350,6 +351,18 @@ fn add_clipboard_exclusions(clipboard: &mut Clipboard, exclude_from_history: boo
 				.setString_forType(ns_string!(""), ns_string!("org.nspasteboard.ConcealedType"));
 		}
 	}
+}
+
+fn extract_html(html: String) -> Option<String> {
+	let start_tag = "<body>";
+	let end_tag = "</body>";
+
+	// Locate the start index of the <body> tag
+	let start_index = html.find(start_tag)? + start_tag.len();
+	// Locate the end index of the </body> tag
+	let end_index = html.find(end_tag)?;
+
+	Some(html[start_index..end_index].to_string())
 }
 
 /// Apple-specific extensions to the [`Set`](crate::Set) builder.

--- a/src/platform/osx.rs
+++ b/src/platform/osx.rs
@@ -353,18 +353,6 @@ fn add_clipboard_exclusions(clipboard: &mut Clipboard, exclude_from_history: boo
 	}
 }
 
-fn extract_html(html: String) -> Option<String> {
-	let start_tag = "<body>";
-	let end_tag = "</body>";
-
-	// Locate the start index of the <body> tag
-	let start_index = html.find(start_tag)? + start_tag.len();
-	// Locate the end index of the </body> tag
-	let end_index = html.find(end_tag)?;
-
-	Some(html[start_index..end_index].to_string())
-}
-
 /// Apple-specific extensions to the [`Set`](crate::Set) builder.
 pub trait SetExtApple: private::Sealed {
 	/// Excludes the data which will be set on the clipboard from being added to

--- a/src/platform/osx.rs
+++ b/src/platform/osx.rs
@@ -207,8 +207,7 @@ impl<'clipboard> Get<'clipboard> {
 	}
 
 	pub(crate) fn html(self) -> Result<String, Error> {
-		let html = unsafe { self.clipboard.string_from_type(NSPasteboardTypeHTML) }?;
-		extract_html(html).ok_or(Error::ConversionFailure)
+		unsafe { self.clipboard.string_from_type(NSPasteboardTypeHTML) }
 	}
 
 	#[cfg(feature = "image-data")]

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -567,6 +567,15 @@ impl<'clipboard> Get<'clipboard> {
 		String::from_utf16(&out[..bytes_read]).map_err(|_| Error::ConversionFailure)
 	}
 
+	pub(crate) fn html(self) -> Result<String, Error> {
+		let format = clipboard_win::register_format("HTML Format")
+			.ok_or_else(|| Error::unknown("unable to register HTML format"))?;
+		let mut out: Vec<u8> = Vec::new();
+		clipboard_win::raw::get_html(format.get(), &mut out)
+				.map_err(|_| Error::unknown("failed to read clipboard string"))?;
+		String::from_utf8(out).map_err(|_| Error::ConversionFailure)
+	}
+
 	#[cfg(feature = "image-data")]
 	pub(crate) fn image(self) -> Result<ImageData<'static>, Error> {
 		const FORMAT: u32 = clipboard_win::formats::CF_DIBV5;

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -568,11 +568,15 @@ impl<'clipboard> Get<'clipboard> {
 	}
 
 	pub(crate) fn html(self) -> Result<String, Error> {
+		let _clipboard_assertion = self.clipboard?;
+
 		let format = clipboard_win::register_format("HTML Format")
 			.ok_or_else(|| Error::unknown("unable to register HTML format"))?;
+
 		let mut out: Vec<u8> = Vec::new();
 		clipboard_win::raw::get_html(format.get(), &mut out)
 			.map_err(|_| Error::unknown("failed to read clipboard string"))?;
+
 		String::from_utf8(out).map_err(|_| Error::ConversionFailure)
 	}
 

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -572,7 +572,7 @@ impl<'clipboard> Get<'clipboard> {
 			.ok_or_else(|| Error::unknown("unable to register HTML format"))?;
 		let mut out: Vec<u8> = Vec::new();
 		clipboard_win::raw::get_html(format.get(), &mut out)
-				.map_err(|_| Error::unknown("failed to read clipboard string"))?;
+			.map_err(|_| Error::unknown("failed to read clipboard string"))?;
 		String::from_utf8(out).map_err(|_| Error::ConversionFailure)
 	}
 


### PR DESCRIPTION
I was unable to run tests, since there was a panic on lib.rs:283, but by running the example I was able to confirm it works on windows and linux.
Closes #130 and #157.