### PR TITLE
macOS: switch to png for image

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -309,7 +309,6 @@ dependencies = [
  "byteorder",
  "num-traits",
  "png",
- "tiff",
 ]
 
 [[package]]
@@ -332,12 +331,6 @@ dependencies = [
  "rustix",
  "windows-sys",
 ]
-
-[[package]]
-name = "jpeg-decoder"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5d4a7da358eff58addd2877a45865158f0d78c911d43a5784ceb7bbf52833b0"
 
 [[package]]
 name = "lazy_static"
@@ -722,17 +715,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tiff"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba1310fcea54c6a9a4fd1aad794ecc02c31682f6bfbecdf460bf19533eed1e3e"
-dependencies = [
- "flate2",
- "jpeg-decoder",
- "weezl",
-]
-
-[[package]]
 name = "tree_magic_mini"
 version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -824,12 +806,6 @@ dependencies = [
  "log",
  "pkg-config",
 ]
-
-[[package]]
-name = "weezl"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9193164d4de03a926d909d3bc7c30543cecb35400c02114792c2cae20d5e2dbb"
 
 [[package]]
 name = "winapi-util"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,7 +22,6 @@ name = "arboard"
 version = "3.4.1"
 dependencies = [
  "clipboard-win",
- "core-graphics",
  "env_logger",
  "image",
  "log",
@@ -102,46 +101,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
-
-[[package]]
-name = "core-graphics"
-version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "970a29baf4110c26fedbc7f82107d42c23f7e88e404c4577ed73fe99ff85a212"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation",
- "core-graphics-types",
- "foreign-types",
- "libc",
-]
-
-[[package]]
-name = "core-graphics-types"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation",
- "libc",
-]
-
-[[package]]
 name = "crc32fast"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -158,7 +117,7 @@ checksum = "3418329ca0ad70234b9735dc4ceed10af4df60eff9c8e7b06cb5e520d92c3535"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.100",
+ "syn",
 ]
 
 [[package]]
@@ -243,33 +202,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foreign-types"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
-dependencies = [
- "foreign-types-macros",
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-macros"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.48",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
 name = "gethostname"
@@ -662,17 +594,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "syn"
-version = "2.0.48"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
 name = "tempfile"
 version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -711,7 +632,7 @@ checksum = "f8b463991b4eab2d801e724172285ec4195c650e8ec79b149e6c2a8e6dd3f783"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.100",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ image-data = ["core-graphics", "image", "windows-sys"]
 wayland-data-control = ["wl-clipboard-rs"]
 
 [dependencies]
+image = { version = "0.25", optional = true, default-features = false, features = ["png"] }
 
 [dev-dependencies]
 env_logger = "0.10.2"
@@ -30,7 +31,6 @@ windows-sys = { version = "0.48.0", optional = true, features = [
 ]}
 clipboard-win = "5.3.1"
 log = "0.4"
-image = { version = "0.25", optional = true, default-features = false, features = ["png"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 # Use `relax-void-encoding`, as that allows us to pass `c_void` instead of implementing `Encode` correctly for `&CGImageRef`
@@ -38,13 +38,11 @@ objc2 = { version = "0.5.1", features = ["relax-void-encoding"] }
 objc2-foundation = { version = "0.2.0", features = ["NSArray", "NSString", "NSEnumerator", "NSGeometry"] }
 objc2-app-kit = { version = "0.2.0", features = ["NSPasteboard", "NSPasteboardItem", "NSImage"] }
 core-graphics = { version = "0.23", optional = true }
-image = { version = "0.25", optional = true, default-features = false, features = ["tiff"] }
 
 [target.'cfg(all(unix, not(any(target_os="macos", target_os="android", target_os="emscripten"))))'.dependencies]
 log = "0.4"
 x11rb = { version = "0.13" }
 wl-clipboard-rs = { version = "0.8", optional = true }
-image = { version = "0.25", optional = true, default-features = false, features = ["png"] }
 parking_lot = "0.12"
 
 [[example]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ rust-version = "1.67.1"
 
 [features]
 default = ["image-data"]
-image-data = ["core-graphics", "image", "windows-sys"]
+image-data = ["image", "windows-sys"]
 wayland-data-control = ["wl-clipboard-rs"]
 
 [dependencies]
@@ -37,7 +37,6 @@ log = "0.4"
 objc2 = { version = "0.5.1", features = ["relax-void-encoding"] }
 objc2-foundation = { version = "0.2.0", features = ["NSArray", "NSString", "NSEnumerator", "NSGeometry"] }
 objc2-app-kit = { version = "0.2.0", features = ["NSPasteboard", "NSPasteboardItem", "NSImage"] }
-core-graphics = { version = "0.23", optional = true }
 
 [target.'cfg(all(unix, not(any(target_os="macos", target_os="android", target_os="emscripten"))))'.dependencies]
 log = "0.4"

--- a/src/common.rs
+++ b/src/common.rs
@@ -148,6 +148,27 @@ impl<'a> ImageData<'a> {
 			bytes: self.bytes.clone().into_owned().into(),
 		}
 	}
+
+	pub(crate) fn encode_as_png(&self) -> Result<Vec<u8>, Error> {
+		use image::ImageEncoder as _;
+
+		if self.bytes.is_empty() || self.width == 0 || self.height == 0 {
+			return Err(Error::ConversionFailure);
+		}
+
+		let mut png_bytes = Vec::new();
+		let encoder = image::codecs::png::PngEncoder::new(&mut png_bytes);
+		encoder
+			.write_image(
+				self.bytes.as_ref(),
+				self.width as u32,
+				self.height as u32,
+				image::ExtendedColorType::Rgba8,
+			)
+			.map_err(|_| Error::ConversionFailure)?;
+
+		Ok(png_bytes)
+	}
 }
 
 #[cfg(any(windows, all(unix, not(target_os = "macos"))))]

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -16,28 +16,6 @@ fn into_unknown<E: std::fmt::Display>(error: E) -> Error {
 	Error::Unknown { description: error.to_string() }
 }
 
-#[cfg(feature = "image-data")]
-fn encode_as_png(image: &ImageData) -> Result<Vec<u8>, Error> {
-	use image::ImageEncoder as _;
-
-	if image.bytes.is_empty() || image.width == 0 || image.height == 0 {
-		return Err(Error::ConversionFailure);
-	}
-
-	let mut png_bytes = Vec::new();
-	let encoder = image::codecs::png::PngEncoder::new(&mut png_bytes);
-	encoder
-		.write_image(
-			image.bytes.as_ref(),
-			image.width as u32,
-			image.height as u32,
-			image::ExtendedColorType::Rgba8,
-		)
-		.map_err(|_| Error::ConversionFailure)?;
-
-	Ok(png_bytes)
-}
-
 /// Clipboard selection
 ///
 /// Linux has a concept of clipboard "selections" which tend to be used in different contexts. This

--- a/src/platform/linux/wayland.rs
+++ b/src/platform/linux/wayland.rs
@@ -7,12 +7,10 @@ use wl_clipboard_rs::{
 	utils::is_primary_selection_supported,
 };
 
-#[cfg(feature = "image-data")]
-use super::encode_as_png;
 use super::{into_unknown, LinuxClipboardKind, WaitConfig};
 use crate::common::Error;
 #[cfg(feature = "image-data")]
-use crate::common::ImageData;
+use crate::ImageData;
 
 #[cfg(feature = "image-data")]
 const MIME_PNG: &str = "image/png";
@@ -164,7 +162,7 @@ impl Clipboard {
 		selection: LinuxClipboardKind,
 		wait: WaitConfig,
 	) -> Result<(), Error> {
-		let image = encode_as_png(&image)?;
+		let image = image.encode_as_png()?;
 		let mut opts = Options::new();
 		opts.foreground(matches!(wait, WaitConfig::Forever));
 		opts.clipboard(selection.try_into()?);

--- a/src/platform/linux/x11.rs
+++ b/src/platform/linux/x11.rs
@@ -42,8 +42,6 @@ use x11rb::{
 	COPY_DEPTH_FROM_PARENT, COPY_FROM_PARENT, NONE,
 };
 
-#[cfg(feature = "image-data")]
-use super::encode_as_png;
 use super::{into_unknown, LinuxClipboardKind, WaitConfig};
 #[cfg(feature = "image-data")]
 use crate::ImageData;
@@ -931,7 +929,7 @@ impl Clipboard {
 		selection: LinuxClipboardKind,
 		wait: WaitConfig,
 	) -> Result<()> {
-		let encoded = encode_as_png(&image)?;
+		let encoded = image.encode_as_png()?;
 		let data = vec![ClipboardData { bytes: encoded, format: self.inner.atoms.PNG_MIME }];
 		self.inner.write(data, selection, wait)
 	}

--- a/src/platform/osx.rs
+++ b/src/platform/osx.rs
@@ -207,18 +207,18 @@ impl<'clipboard> Get<'clipboard> {
 
 	#[cfg(feature = "image-data")]
 	pub(crate) fn image(self) -> Result<ImageData<'static>, Error> {
-		use objc2_app_kit::NSPasteboardTypeTIFF;
+		use objc2_app_kit::NSPasteboardTypePNG;
 		use std::io::Cursor;
 
 		// XXX: There does not appear to be an alternative for obtaining images without the need for
 		// autorelease behavior.
 		let image = autoreleasepool(|_| {
-			let image_data = unsafe { self.clipboard.pasteboard.dataForType(NSPasteboardTypeTIFF) }
+			let image_data = unsafe { self.clipboard.pasteboard.dataForType(NSPasteboardTypePNG) }
 				.ok_or(Error::ContentNotAvailable)?;
 
 			let data = Cursor::new(image_data.bytes());
 
-			let reader = image::io::Reader::with_format(data, image::ImageFormat::Tiff);
+			let reader = image::io::Reader::with_format(data, image::ImageFormat::Png);
 			reader.decode().map_err(|_| Error::ConversionFailure)
 		})?;
 

--- a/src/platform/osx.rs
+++ b/src/platform/osx.rs
@@ -8,8 +8,6 @@ the Apache 2.0 or the MIT license at the licensee's choice. The terms
 and conditions of the chosen license apply to this file.
 */
 
-#[cfg(feature = "image-data")]
-use crate::common::ImageData;
 use crate::common::{private, Error};
 use objc2::{
 	msg_send_id,
@@ -23,69 +21,8 @@ use std::{
 	borrow::Cow,
 	panic::{RefUnwindSafe, UnwindSafe},
 };
-
-/// Returns an NSImage object on success.
 #[cfg(feature = "image-data")]
-fn image_from_pixels(
-	pixels: Vec<u8>,
-	width: usize,
-	height: usize,
-) -> Result<Id<objc2_app_kit::NSImage>, Box<dyn std::error::Error>> {
-	use core_graphics::{
-		base::{kCGBitmapByteOrderDefault, kCGImageAlphaLast, kCGRenderingIntentDefault, CGFloat},
-		color_space::CGColorSpace,
-		data_provider::{CGDataProvider, CustomData},
-		image::{CGImage, CGImageRef},
-	};
-	use objc2_app_kit::NSImage;
-	use objc2_foundation::NSSize;
-	use std::ffi::c_void;
-
-	#[derive(Debug)]
-	struct PixelArray {
-		data: Vec<u8>,
-	}
-
-	impl CustomData for PixelArray {
-		unsafe fn ptr(&self) -> *const u8 {
-			self.data.as_ptr()
-		}
-		unsafe fn len(&self) -> usize {
-			self.data.len()
-		}
-	}
-
-	let colorspace = CGColorSpace::create_device_rgb();
-	let pixel_data: Box<Box<dyn CustomData>> = Box::new(Box::new(PixelArray { data: pixels }));
-	let provider = unsafe { CGDataProvider::from_custom_data(pixel_data) };
-
-	let cg_image = CGImage::new(
-		width,
-		height,
-		8,
-		32,
-		4 * width,
-		&colorspace,
-		kCGBitmapByteOrderDefault | kCGImageAlphaLast,
-		&provider,
-		false,
-		kCGRenderingIntentDefault,
-	);
-
-	// Convert the owned `CGImage` into a reference `&CGImageRef`, and pass
-	// that as `*const c_void`, since `CGImageRef` does not implement
-	// `RefEncode`.
-	let cg_image: *const CGImageRef = &*cg_image;
-	let cg_image: *const c_void = cg_image.cast();
-
-	let size = NSSize { width: width as CGFloat, height: height as CGFloat };
-	// XXX: Use `NSImage::initWithCGImage_size` once `objc2-app-kit` supports
-	// CoreGraphics.
-	let image: Id<NSImage> =
-		unsafe { msg_send_id![NSImage::alloc(), initWithCGImage: cg_image, size:size] };
-
-	Ok(image)
-}
+use {crate::ImageData, objc2_app_kit::NSPasteboardTypePNG};
 
 pub(crate) struct Clipboard {
 	pasteboard: Id<NSPasteboard>,
@@ -207,7 +144,6 @@ impl<'clipboard> Get<'clipboard> {
 
 	#[cfg(feature = "image-data")]
 	pub(crate) fn image(self) -> Result<ImageData<'static>, Error> {
-		use objc2_app_kit::NSPasteboardTypePNG;
 		use std::io::Cursor;
 
 		// XXX: There does not appear to be an alternative for obtaining images without the need for
@@ -295,14 +231,22 @@ impl<'clipboard> Set<'clipboard> {
 
 	#[cfg(feature = "image-data")]
 	pub(crate) fn image(self, data: ImageData) -> Result<(), Error> {
-		let pixels = data.bytes.into();
-		let image = image_from_pixels(pixels, data.width, data.height)
-			.map_err(|_| Error::ConversionFailure)?;
+		use objc2_foundation::NSData;
+		use std::ffi::c_void;
 
 		self.clipboard.clear();
 
-		let image_array = NSArray::from_vec(vec![ProtocolObject::from_id(image)]);
-		let success = unsafe { self.clipboard.pasteboard.writeObjects(&image_array) };
+		let encoded = data.encode_as_png()?;
+		let success = unsafe {
+			let ns_data = {
+				NSData::initWithBytes_length(
+					NSData::alloc(),
+					encoded.as_ptr() as *mut c_void,
+					encoded.len(),
+				)
+			};
+			self.clipboard.pasteboard.setData_forType(Some(&ns_data), NSPasteboardTypePNG)
+		};
 
 		add_clipboard_exclusions(self.clipboard, self.exclude_from_history);
 

--- a/src/platform/osx.rs
+++ b/src/platform/osx.rs
@@ -238,13 +238,7 @@ impl<'clipboard> Set<'clipboard> {
 
 		let encoded = data.encode_as_png()?;
 		let success = unsafe {
-			let ns_data = {
-				NSData::initWithBytes_length(
-					NSData::alloc(),
-					encoded.as_ptr() as *mut c_void,
-					encoded.len(),
-				)
-			};
+			let ns_data = NSData::from_vec(encoded);
 			self.clipboard.pasteboard.setData_forType(Some(&ns_data), NSPasteboardTypePNG)
 		};
 

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -17,9 +17,6 @@ use std::{borrow::Cow, marker::PhantomData, thread, time::Duration};
 mod image_data {
 	use super::*;
 	use crate::common::ScopeGuard;
-	use image::codecs::png::PngEncoder;
-	use image::ExtendedColorType;
-	use image::ImageEncoder;
 	use std::{convert::TryInto, ffi::c_void, io, mem::size_of, ptr::copy_nonoverlapping};
 	use windows_sys::Win32::{
 		Foundation::HGLOBAL,
@@ -128,18 +125,7 @@ mod image_data {
 	}
 
 	pub(super) fn add_png_file(image: &ImageData) -> Result<(), Error> {
-		// Try encoding the image as PNG.
-		let mut buf = Vec::new();
-		let encoder = PngEncoder::new(&mut buf);
-
-		encoder
-			.write_image(
-				&image.bytes,
-				image.width as u32,
-				image.height as u32,
-				ExtendedColorType::Rgba8,
-			)
-			.map_err(|_| Error::ConversionFailure)?;
+		let buf = image.encode_as_png()?;
 
 		// Register PNG format.
 		let format_id = match clipboard_win::register_format("PNG") {


### PR DESCRIPTION
Used png for handling images on all platform. On macOS dropped the dependency on core-graphics since now an image is directly stored as png