### PR TITLE
Update to objc2 v0.6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
         os: [macos-latest, windows-latest, ubuntu-latest]
         # Latest stable and MSRV. We only run checks with all features enabled
         # for the MSRV build to keep CI fast, since other configurations should also work.
-        rust_version: [stable, "1.67.1"]
+        rust_version: [stable, "1.71.0"]
     steps:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Changed
+- Updated `objc2` to `v0.6`.
+- Raised MSRV to 1.71.0.
+
 ## 3.4.1 on 2024-12-09
 
 ### Added
@@ -97,11 +101,11 @@ from a `write` call to a X11 and Wayland or clipboard
 - Updated `wl-clipboard-rs` to the version `0.6`.
 - Updated `x11rb` to the version `0.10`.
 - Cleaned up spelling in documentation
-- (Breaking) Functions that used to accept `String` now take `Into<Cow<'a>, str>` instead. 
+- (Breaking) Functions that used to accept `String` now take `Into<Cow<'a>, str>` instead.
 This avoids cloning the string more times then necessary on platforms that can.
 - (Breaking) `Error` is now marked as `#[non_exhaustive]`.
 - (Breaking) Removed all platform specific modules and clipboard structures from the public API.
-If you were using these directly, the recommended replacement is using `arboard::Clipboard` and 
+If you were using these directly, the recommended replacement is using `arboard::Clipboard` and
 the new platform-specific extension traits instead.
 - (Breaking) On Windows, the clipboard is now opened once per call to `Clipboard::new()` instead of on
 each operation. This means that instances of `Clipboard` should be dropped once you're performed the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,12 +22,13 @@ name = "arboard"
 version = "3.4.1"
 dependencies = [
  "clipboard-win",
- "core-graphics",
  "env_logger",
  "image",
  "log",
  "objc2",
  "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
  "objc2-foundation",
  "parking_lot",
  "windows-sys",
@@ -49,18 +50,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
-
-[[package]]
-name = "block2"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43ff7d91d3c1d568065b06c899777d1e48dcf76103a672a0adbc238a7f247f1e"
-dependencies = [
- "objc2",
-]
+checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
 
 [[package]]
 name = "bytecount"
@@ -102,46 +94,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
-
-[[package]]
-name = "core-graphics"
-version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "970a29baf4110c26fedbc7f82107d42c23f7e88e404c4577ed73fe99ff85a212"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation",
- "core-graphics-types",
- "foreign-types",
- "libc",
-]
-
-[[package]]
-name = "core-graphics-types"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation",
- "libc",
-]
-
-[[package]]
 name = "crc32fast"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -158,7 +110,7 @@ checksum = "3418329ca0ad70234b9735dc4ceed10af4df60eff9c8e7b06cb5e520d92c3535"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.100",
+ "syn",
 ]
 
 [[package]]
@@ -243,33 +195,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foreign-types"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
-dependencies = [
- "foreign-types-macros",
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-macros"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.48",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
 name = "gethostname"
@@ -446,58 +371,74 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc-sys"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da284c198fb9b7b0603f8635185e85fbd5b64ee154b1ed406d489077de2d6d60"
-
-[[package]]
 name = "objc2"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4b25e1034d0e636cd84707ccdaa9f81243d399196b8a773946dcffec0401659"
+checksum = "3531f65190d9cff863b77a99857e74c314dd16bf56c538c4b57c7cbc3f3a6e59"
 dependencies = [
- "objc-sys",
  "objc2-encode",
 ]
 
 [[package]]
 name = "objc2-app-kit"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb79768a710a9a1798848179edb186d1af7e8a8679f369e4b8d201dd2a034047"
+checksum = "5906f93257178e2f7ae069efb89fbd6ee94f0592740b5f8a1512ca498814d0fb"
 dependencies = [
- "block2",
+ "bitflags 2.8.0",
  "objc2",
- "objc2-core-data",
+ "objc2-core-graphics",
  "objc2-foundation",
 ]
 
 [[package]]
-name = "objc2-core-data"
-version = "0.2.0"
+name = "objc2-core-foundation"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e092bc42eaf30a08844e6a076938c60751225ec81431ab89f5d1ccd9f958d6c"
+checksum = "daeaf60f25471d26948a1c2f840e3f7d86f4109e3af4e8e4b5cd70c39690d925"
 dependencies = [
- "block2",
+ "bitflags 2.8.0",
  "objc2",
- "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-graphics"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dca602628b65356b6513290a21a6405b4d4027b8b250f0b98dddbb28b7de02"
+dependencies = [
+ "bitflags 2.8.0",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-io-surface",
 ]
 
 [[package]]
 name = "objc2-encode"
-version = "4.0.1"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88658da63e4cc2c8adb1262902cd6af51094df0488b760d6fd27194269c0950a"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "objc2-foundation"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfaefe14254871ea16c7d88968c0ff14ba554712a20d76421eec52f0a7fb8904"
+checksum = "3a21c6c9014b82c39515db5b396f91645182611c97d24637cf56ac01e5f8d998"
 dependencies = [
- "block2",
+ "bitflags 2.8.0",
  "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-surface"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "161a8b87e32610086e1a7a9e9ec39f84459db7b3a0881c1f16ca5a2605581c19"
+dependencies = [
+ "bitflags 2.8.0",
+ "objc2",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -632,7 +573,7 @@ version = "0.38.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b426b0506e5d50a7d8dafcf2e81471400deb602392c7dd110815afb4eaf02a3"
 dependencies = [
- "bitflags 2.4.0",
+ "bitflags 2.8.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -662,17 +603,6 @@ name = "syn"
 version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52205623b1b0f064a4e71182c3b18ae902267282930c6d5462c91b859668426e"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
-version = "2.0.48"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -718,7 +648,7 @@ checksum = "f8b463991b4eab2d801e724172285ec4195c650e8ec79b149e6c2a8e6dd3f783"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.100",
+ "syn",
 ]
 
 [[package]]
@@ -772,7 +702,7 @@ version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ca7d52347346f5473bf2f56705f360e8440873052e575e55890c4fa57843ed3"
 dependencies = [
- "bitflags 2.4.0",
+ "bitflags 2.8.0",
  "nix",
  "wayland-backend",
  "wayland-scanner",
@@ -784,7 +714,7 @@ version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e253d7107ba913923dc253967f35e8561a3c65f914543e46843c88ddd729e21c"
 dependencies = [
- "bitflags 2.4.0",
+ "bitflags 2.8.0",
  "wayland-backend",
  "wayland-client",
  "wayland-scanner",
@@ -796,7 +726,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad1f61b76b6c2d8742e10f9ba5c3737f6530b4c243132c2a2ccc8aa96fe25cd6"
 dependencies = [
- "bitflags 2.4.0",
+ "bitflags 2.8.0",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,11 @@ default = ["image-data"]
 image-data = [
     "dep:objc2-core-graphics",
     "dep:objc2-core-foundation",
-    "dep:image",
-    "dep:windows-sys",
+    "image",
+    "windows-sys",
+    "core-graphics",
 ]
-wayland-data-control = ["dep:wl-clipboard-rs"]
+wayland-data-control = ["wl-clipboard-rs"]
 
 # For backwards compat
 core-graphics = ["dep:objc2-core-graphics"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,19 +1,34 @@
 [package]
 name = "arboard"
 version = "3.4.1"
-authors = ["Artur Kovacs <kovacs.artur.barnabas@gmail.com>", "Avi Weinstock <aweinstock314@gmail.com>", "Arboard contributors"]
+authors = [
+    "Artur Kovacs <kovacs.artur.barnabas@gmail.com>",
+    "Avi Weinstock <aweinstock314@gmail.com>",
+    "Arboard contributors",
+]
 description = "Image and text handling for the OS clipboard."
 repository = "https://github.com/1Password/arboard"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 keywords = ["clipboard", "image"]
 edition = "2021"
-rust-version = "1.67.1"
+rust-version = "1.71.0"
 
 [features]
 default = ["image-data"]
-image-data = ["core-graphics", "image", "windows-sys"]
-wayland-data-control = ["wl-clipboard-rs"]
+image-data = [
+    "dep:objc2-core-graphics",
+    "dep:objc2-core-foundation",
+    "dep:image",
+    "dep:windows-sys",
+]
+wayland-data-control = ["dep:wl-clipboard-rs"]
+
+# For backwards compat
+core-graphics = ["dep:objc2-core-graphics"]
+windows-sys = ["dep:windows-sys"]
+image = ["dep:image"]
+wl-clipboard-rs = ["dep:wl-clipboard-rs"]
 
 [dependencies]
 
@@ -27,24 +42,50 @@ windows-sys = { version = "0.48.0", optional = true, features = [
     "Win32_System_DataExchange",
     "Win32_System_Memory",
     "Win32_System_Ole",
-]}
+] }
 clipboard-win = "5.3.1"
 log = "0.4"
-image = { version = "0.25", optional = true, default-features = false, features = ["png"] }
+image = { version = "0.25", optional = true, default-features = false, features = [
+    "png",
+] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-# Use `relax-void-encoding`, as that allows us to pass `c_void` instead of implementing `Encode` correctly for `&CGImageRef`
-objc2 = { version = "0.5.1", features = ["relax-void-encoding"] }
-objc2-foundation = { version = "0.2.0", features = ["NSArray", "NSString", "NSEnumerator", "NSGeometry"] }
-objc2-app-kit = { version = "0.2.0", features = ["NSPasteboard", "NSPasteboardItem", "NSImage"] }
-core-graphics = { version = "0.23", optional = true }
-image = { version = "0.25", optional = true, default-features = false, features = ["tiff"] }
+objc2 = "0.6.0"
+objc2-foundation = { version = "0.3.0", default-features = false, features = [
+    "std",
+    "NSArray",
+    "NSString",
+    "NSEnumerator",
+    "NSGeometry",
+] }
+objc2-app-kit = { version = "0.3.0", default-features = false, features = [
+    "std",
+    "objc2-core-graphics",
+    "NSPasteboard",
+    "NSPasteboardItem",
+    "NSImage",
+] }
+objc2-core-foundation = { version = "0.3.0", default-features = false, optional = true, features = [
+    "std",
+    "CFCGTypes",
+] }
+objc2-core-graphics = { version = "0.3.0", default-features = false, optional = true, features = [
+    "std",
+    "CGImage",
+    "CGColorSpace",
+    "CGDataProvider",
+] }
+image = { version = "0.25", optional = true, default-features = false, features = [
+    "tiff",
+] }
 
 [target.'cfg(all(unix, not(any(target_os="macos", target_os="android", target_os="emscripten"))))'.dependencies]
 log = "0.4"
 x11rb = { version = "0.13" }
 wl-clipboard-rs = { version = "0.8", optional = true }
-image = { version = "0.25", optional = true, default-features = false, features = ["png"] }
+image = { version = "0.25", optional = true, default-features = false, features = [
+    "png",
+] }
 parking_lot = "0.12"
 
 [[example]]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Latest version](https://img.shields.io/crates/v/arboard?color=mediumvioletred)](https://crates.io/crates/arboard)
 [![Documentation](https://docs.rs/arboard/badge.svg)](https://docs.rs/arboard)
-![MSRV](https://img.shields.io/badge/rustc-1.67.1+-blue.svg)
+![MSRV](https://img.shields.io/badge/rustc-1.71.0+-blue.svg)
 
 ## General
 

--- a/src/platform/osx.rs
+++ b/src/platform/osx.rs
@@ -218,7 +218,8 @@ impl<'clipboard> Get<'clipboard> {
 			let image_data = unsafe { self.clipboard.pasteboard.dataForType(NSPasteboardTypeTIFF) }
 				.ok_or(Error::ContentNotAvailable)?;
 
-			let data = Cursor::new(image_data.to_vec());
+			// SAFETY: The data is not modified while in use here.
+			let data = Cursor::new(unsafe { image_data.as_bytes_unchecked() });
 
 			let reader = image::io::Reader::with_format(data, image::ImageFormat::Tiff);
 			reader.decode().map_err(|_| Error::ConversionFailure)

--- a/src/platform/osx.rs
+++ b/src/platform/osx.rs
@@ -52,7 +52,7 @@ fn image_from_pixels(
 	}
 
 	let provider = {
-		let pixels: Box<[u8]> = pixels.into();
+		let pixels = pixels.into_boxed_slice();
 		let len = pixels.len();
 		let pixels: *mut [u8] = Box::into_raw(pixels);
 		// Convert slice pointer to thin pointer.

--- a/src/platform/osx.rs
+++ b/src/platform/osx.rs
@@ -41,14 +41,14 @@ fn image_from_pixels(
 	use objc2_foundation::NSSize;
 	use std::{
 		ffi::c_void,
-		ptr::{self, slice_from_raw_parts_mut, NonNull},
+		ptr::{self, NonNull},
 	};
 
 	unsafe extern "C-unwind" fn release(_info: *mut c_void, data: NonNull<c_void>, size: usize) {
 		let data = data.cast::<u8>();
-		let slice = slice_from_raw_parts_mut(data.as_ptr(), size);
+		let slice = NonNull::slice_from_raw_parts(data, size);
 		// SAFETY: This is the same slice that we got from `Box::into_raw`.
-		drop(unsafe { Box::from_raw(slice) })
+		drop(unsafe { Box::from_raw(slice.as_ptr()) })
 	}
 
 	let provider = {


### PR DESCRIPTION
This includes using the new crate `objc2-core-graphics`, which notably does not have the `CustomData` helper that `core-graphics`. This is probably for the better, as it allows us to avoid a double-boxing of the data.

This also:
- Bumps MSRV to 1.71 (required for `extern "C-unwind"` in `objc2`).
- Uses `dep:*` syntax (to avoid breaking changes from added/removed feature flags).