### PR TITLE
Bump Ubuntu runner version for cargo-semver-checks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,7 +93,7 @@ jobs:
         run: cargo miri test windows --features image-data
 
   semver:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     - name: Check semver


### PR DESCRIPTION
In #163 I [encountered a test failure](https://github.com/1Password/arboard/actions/runs/13300556577/job/37141617741) where the `cargo-semver-checks` job couldn't find its required version of `glibc`:
```
/home/runner/.cargo/bin/cargo semver-checks --version
/home/runner/work/_temp/1b9e9d38-635b-4e01-a948-26e3175b21e2/cargo-semver-checks: /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.38' not found (required by /home/runner/work/_temp/1b9e9d38-635b-4e01-a948-26e3175b21e2/cargo-semver-checks)
/home/runner/work/_temp/1b9e9d38-635b-4e01-a948-26e3175b21e2/cargo-semver-checks: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found (required by /home/runner/work/_temp/1b9e9d38-635b-4e01-a948-26e3175b21e2/cargo-semver-checks)
```

This attempts to resolve the issue by updating Ubuntu and therefore the `glibc` version. We don't depend on anything specific in the runner image to run `cargo-semver-checks` so this shouldn't mask any other problems like it might when doing `cargo build`.