### PR TITLE
Add `file_list` to `Get` interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,6 +31,7 @@ dependencies = [
  "objc2-core-graphics",
  "objc2-foundation",
  "parking_lot",
+ "percent-encoding",
  "windows-sys",
  "wl-clipboard-rs",
  "x11rb",
@@ -404,6 +405,12 @@ dependencies = [
  "smallvec",
  "windows-targets 0.52.6",
 ]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "petgraph"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ objc2-foundation = { version = "0.3.0", default-features = false, features = [
     "NSString",
     "NSEnumerator",
     "NSGeometry",
+    "NSValue",
 ] }
 objc2-app-kit = { version = "0.3.0", default-features = false, features = [
     "std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ windows-sys = { version = ">=0.52.0, <0.60.0", optional = true, features = [
     "Win32_System_Memory",
     "Win32_System_Ole",
 ] }
-clipboard-win = "5.3.1"
+clipboard-win = { version = "5.3.1", features = ["std"] }
 log = "0.4"
 image = { version = "0.25", optional = true, default-features = false, features = [
     "png",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,7 @@ image = { version = "0.25", optional = true, default-features = false, features 
     "png",
 ] }
 parking_lot = "0.12"
+percent-encoding = "2.3.1"
 
 [[example]]
 name = "get_image"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ and conditions of the chosen license apply to this file.
 #![warn(unreachable_pub)]
 
 mod common;
-use std::borrow::Cow;
+use std::{borrow::Cow, path::PathBuf};
 
 pub use common::Error;
 #[cfg(feature = "image-data")]
@@ -196,6 +196,11 @@ impl Get<'_> {
 	/// Completes the "get" operation by fetching HTML from the clipboard.
 	pub fn html(self) -> Result<String, Error> {
 		self.platform.html()
+	}
+
+	/// Completes the "get" operation by fetching a list of file paths from the clipboard.
+	pub fn file_list(self) -> Result<Vec<PathBuf>, Error> {
+		self.platform.file_list()
 	}
 }
 

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -38,6 +38,10 @@ fn encode_as_png(image: &ImageData) -> Result<Vec<u8>, Error> {
 	Ok(png_bytes)
 }
 
+fn extract_paths_from_uri_list(uri_list: String) -> Vec<PathBuf> {
+	uri_list.lines().filter_map(|s| s.strip_prefix("file://").map(PathBuf::from)).collect()
+}
+
 /// Clipboard selection
 ///
 /// Linux has a concept of clipboard "selections" which tend to be used in different contexts. This
@@ -132,7 +136,11 @@ impl<'clipboard> Get<'clipboard> {
 	}
 
 	pub(crate) fn file_list(self) -> Result<Vec<PathBuf>, Error> {
-		todo!()
+		match self.clipboard {
+			Clipboard::X11(clipboard) => clipboard.get_file_list(self.selection),
+			#[cfg(feature = "wayland-data-control")]
+			Clipboard::WlDataControl(clipboard) => clipboard.get_file_list(self.selection),
+		}
 	}
 }
 

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, time::Instant};
+use std::{borrow::Cow, path::PathBuf, time::Instant};
 
 #[cfg(feature = "wayland-data-control")]
 use log::{trace, warn};
@@ -129,6 +129,10 @@ impl<'clipboard> Get<'clipboard> {
 			#[cfg(feature = "wayland-data-control")]
 			Clipboard::WlDataControl(clipboard) => clipboard.get_html(self.selection),
 		}
+	}
+
+	pub(crate) fn file_list(self) -> Result<Vec<PathBuf>, Error> {
+		todo!()
 	}
 }
 

--- a/src/platform/linux/wayland.rs
+++ b/src/platform/linux/wayland.rs
@@ -8,7 +8,7 @@ use wl_clipboard_rs::{
 
 #[cfg(feature = "image-data")]
 use super::encode_as_png;
-use super::{extract_paths_from_uri_list, into_unknown, LinuxClipboardKind, WaitConfig};
+use super::{into_unknown, paths_from_uri_list, LinuxClipboardKind, WaitConfig};
 use crate::common::Error;
 #[cfg(feature = "image-data")]
 use crate::common::ImageData;
@@ -187,6 +187,6 @@ impl Clipboard {
 		selection: LinuxClipboardKind,
 	) -> Result<Vec<PathBuf>, Error> {
 		self.string_for_mime(selection, paste::MimeType::Specific("text/uri-list"))
-			.map(extract_paths_from_uri_list)
+			.map(paths_from_uri_list)
 	}
 }

--- a/src/platform/linux/wayland.rs
+++ b/src/platform/linux/wayland.rs
@@ -1,5 +1,4 @@
-use std::borrow::Cow;
-use std::io::Read;
+use std::{borrow::Cow, io::Read, path::PathBuf};
 
 use wl_clipboard_rs::{
 	copy::{self, Error as CopyError, MimeSource, MimeType, Options, Source},
@@ -9,7 +8,7 @@ use wl_clipboard_rs::{
 
 #[cfg(feature = "image-data")]
 use super::encode_as_png;
-use super::{into_unknown, LinuxClipboardKind, WaitConfig};
+use super::{extract_paths_from_uri_list, into_unknown, LinuxClipboardKind, WaitConfig};
 use crate::common::Error;
 #[cfg(feature = "image-data")]
 use crate::common::ImageData;
@@ -181,5 +180,13 @@ impl Clipboard {
 		let source = Source::Bytes(image.into());
 		opts.copy(source, MimeType::Specific(MIME_PNG.into())).map_err(into_unknown)?;
 		Ok(())
+	}
+
+	pub(crate) fn get_file_list(
+		&mut self,
+		selection: LinuxClipboardKind,
+	) -> Result<Vec<PathBuf>, Error> {
+		self.string_for_mime(selection, paste::MimeType::Specific("text/uri-list"))
+			.map(extract_paths_from_uri_list)
 	}
 }

--- a/src/platform/linux/x11.rs
+++ b/src/platform/linux/x11.rs
@@ -45,7 +45,7 @@ use x11rb::{
 
 #[cfg(feature = "image-data")]
 use super::encode_as_png;
-use super::{extract_paths_from_uri_list, into_unknown, LinuxClipboardKind, WaitConfig};
+use super::{into_unknown, paths_from_uri_list, LinuxClipboardKind, WaitConfig};
 #[cfg(feature = "image-data")]
 use crate::ImageData;
 use crate::{common::ScopeGuard, Error};
@@ -949,7 +949,7 @@ impl Clipboard {
 
 		String::from_utf8(result.bytes)
 			.map_err(|_| Error::ConversionFailure)
-			.map(extract_paths_from_uri_list)
+			.map(paths_from_uri_list)
 	}
 }
 

--- a/src/platform/linux/x11.rs
+++ b/src/platform/linux/x11.rs
@@ -16,6 +16,7 @@ use std::{
 	borrow::Cow,
 	cell::RefCell,
 	collections::{hash_map::Entry, HashMap},
+	path::PathBuf,
 	sync::{
 		atomic::{AtomicBool, Ordering},
 		Arc,
@@ -44,7 +45,7 @@ use x11rb::{
 
 #[cfg(feature = "image-data")]
 use super::encode_as_png;
-use super::{into_unknown, LinuxClipboardKind, WaitConfig};
+use super::{extract_paths_from_uri_list, into_unknown, LinuxClipboardKind, WaitConfig};
 #[cfg(feature = "image-data")]
 use crate::ImageData;
 use crate::{common::ScopeGuard, Error};
@@ -77,6 +78,7 @@ x11rb::atom_manager! {
 		TEXT_MIME_UNKNOWN: b"text/plain",
 
 		HTML: b"text/html",
+		URI_LIST: b"text/uri-list",
 
 		PNG_MIME: b"image/png",
 
@@ -940,6 +942,14 @@ impl Clipboard {
 		let encoded = encode_as_png(&image)?;
 		let data = vec![ClipboardData { bytes: encoded, format: self.inner.atoms.PNG_MIME }];
 		self.inner.write(data, selection, wait)
+	}
+
+	pub(crate) fn get_file_list(&self, selection: LinuxClipboardKind) -> Result<Vec<PathBuf>> {
+		let result = self.inner.read(&[self.inner.atoms.URI_LIST], selection)?;
+
+		String::from_utf8(result.bytes)
+			.map_err(|_| Error::ConversionFailure)
+			.map(extract_paths_from_uri_list)
 	}
 }
 

--- a/src/platform/osx.rs
+++ b/src/platform/osx.rs
@@ -22,6 +22,7 @@ use objc2_foundation::{ns_string, NSArray, NSString};
 use std::{
 	borrow::Cow,
 	panic::{RefUnwindSafe, UnwindSafe},
+	path::PathBuf,
 };
 
 /// Returns an NSImage object on success.
@@ -236,6 +237,10 @@ impl<'clipboard> Get<'clipboard> {
 			height: height as usize,
 			bytes: rgba.into_raw().into(),
 		})
+	}
+
+	pub(crate) fn file_list(self) -> Result<Vec<PathBuf>, Error> {
+		todo!()
 	}
 }
 

--- a/src/platform/osx.rs
+++ b/src/platform/osx.rs
@@ -17,8 +17,11 @@ use objc2::{
 	runtime::ProtocolObject,
 	ClassType,
 };
-use objc2_app_kit::{NSPasteboard, NSPasteboardTypeHTML, NSPasteboardTypeString};
-use objc2_foundation::{ns_string, NSArray, NSString};
+use objc2_app_kit::{
+	NSPasteboard, NSPasteboardTypeHTML, NSPasteboardTypeString,
+	NSPasteboardURLReadingFileURLsOnlyKey,
+};
+use objc2_foundation::{ns_string, NSArray, NSDictionary, NSNumber, NSString, NSURL};
 use std::{
 	borrow::Cow,
 	panic::{RefUnwindSafe, UnwindSafe},
@@ -240,7 +243,32 @@ impl<'clipboard> Get<'clipboard> {
 	}
 
 	pub(crate) fn file_list(self) -> Result<Vec<PathBuf>, Error> {
-		todo!()
+		autoreleasepool(|_| {
+			let class_array = NSArray::from_slice(&[NSURL::class()]);
+			let options = NSDictionary::from_slices(
+				&[unsafe { NSPasteboardURLReadingFileURLsOnlyKey }],
+				&[NSNumber::new_bool(true).as_ref()],
+			);
+			let objects = unsafe {
+				self.clipboard
+					.pasteboard
+					.readObjectsForClasses_options(&class_array, Some(&options))
+			};
+
+			objects
+				.map(|array| {
+					array
+						.iter()
+						.filter_map(|obj| {
+							obj.downcast::<NSURL>().ok().and_then(|url| {
+								unsafe { url.path() }.map(|p| PathBuf::from(p.to_string()))
+							})
+						})
+						.collect::<Vec<_>>()
+				})
+				.filter(|file_list| !file_list.is_empty())
+				.ok_or(Error::ContentNotAvailable)
+		})
 	}
 }
 

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -11,7 +11,7 @@ and conditions of the chosen license apply to this file.
 #[cfg(feature = "image-data")]
 use crate::common::ImageData;
 use crate::common::{private, Error};
-use std::{borrow::Cow, marker::PhantomData, thread, time::Duration};
+use std::{borrow::Cow, marker::PhantomData, path::PathBuf, thread, time::Duration};
 
 #[cfg(feature = "image-data")]
 mod image_data {
@@ -634,6 +634,10 @@ impl<'clipboard> Get<'clipboard> {
 			.map_err(|_| Error::unknown("failed to read clipboard image data"))?;
 
 		image_data::read_cf_dibv5(&data)
+	}
+
+	pub(crate) fn file_list(self) -> Result<Vec<PathBuf>, Error> {
+		todo!()
 	}
 }
 

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -637,7 +637,13 @@ impl<'clipboard> Get<'clipboard> {
 	}
 
 	pub(crate) fn file_list(self) -> Result<Vec<PathBuf>, Error> {
-		todo!()
+		let _clipboard_assertion = self.clipboard?;
+
+		let mut file_list = Vec::new();
+		clipboard_win::raw::get_file_list_path(&mut file_list)
+			.map_err(|_| Error::ContentNotAvailable)?;
+
+		Ok(file_list)
 	}
 }
 


### PR DESCRIPTION
Opening as a draft since osx and wayland are still to do.
While Windows would simply return file paths, X11 returns a uri-list, should we maybe decide a single format to use in all platforms?
Close #51