### PR TITLE
use `Error::unknown` on Linux and macOS code too

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -90,7 +90,6 @@ impl std::fmt::Debug for Error {
 }
 
 impl Error {
-	#[cfg(windows)]
 	pub(crate) fn unknown<M: Into<String>>(message: M) -> Self {
 		Error::Unknown { description: message.into() }
 	}

--- a/src/platform/linux/wayland.rs
+++ b/src/platform/linux/wayland.rs
@@ -72,7 +72,7 @@ impl Clipboard {
 
 			Err(PasteError::PrimarySelectionUnsupported) => Err(Error::ClipboardNotSupported),
 
-			Err(err) => Err(Error::Unknown { description: err.to_string() }),
+			Err(err) => Err(into_unknown(err)),
 		}
 	}
 
@@ -163,7 +163,7 @@ impl Clipboard {
 				Err(Error::ContentNotAvailable)
 			}
 
-			Err(err) => Err(Error::Unknown { description: err.to_string() }),
+			Err(err) => Err(into_unknown(err)),
 		}
 	}
 

--- a/src/platform/linux/x11.rs
+++ b/src/platform/linux/x11.rs
@@ -134,16 +134,10 @@ impl XContext {
 	fn new() -> Result<Self> {
 		// create a new connection to an X11 server
 		let (conn, screen_num): (RustConnection, _) =
-			RustConnection::connect(None).map_err(|_| Error::Unknown {
-				description: String::from(
-					"X11 server connection timed out because it was unreachable",
-				),
+			RustConnection::connect(None).map_err(|_| {
+				Error::unknown("X11 server connection timed out because it was unreachable")
 			})?;
-		let screen = conn
-			.setup()
-			.roots
-			.get(screen_num)
-			.ok_or(Error::Unknown { description: String::from("no screen found") })?;
+		let screen = conn.setup().roots.get(screen_num).ok_or(Error::unknown("no screen found"))?;
 		let win_id = conn.generate_id().map_err(into_unknown)?;
 
 		let event_mask =
@@ -225,9 +219,7 @@ impl Inner {
 		wait: WaitConfig,
 	) -> Result<()> {
 		if self.serve_stopped.load(Ordering::Relaxed) {
-			return Err(Error::Unknown {
-                description: "The clipboard handler thread seems to have stopped. Logging messages may reveal the cause. (See the `log` crate.)".into()
-            });
+			return Err(Error::unknown("The clipboard handler thread seems to have stopped. Logging messages may reveal the cause. (See the `log` crate.)"));
 		}
 
 		let server_win = self.server.win_id;
@@ -527,9 +519,7 @@ impl Inner {
 			Ok(ReadSelNotifyResult::IncrStarted)
 		} else {
 			// this should never happen, we have sent a request only for supported types
-			Err(Error::Unknown {
-				description: String::from("incorrect type received from clipboard"),
-			})
+			Err(Error::unknown("incorrect type received from clipboard"))
 		}
 	}
 
@@ -714,9 +704,7 @@ impl Inner {
 			return Ok(());
 		}
 
-		Err(Error::Unknown {
-			description: "The handover was not finished and the condvar didn't time out, yet the condvar wait ended. This should be unreachable.".into()
-		})
+		Err(Error::unknown("The handover was not finished and the condvar didn't time out, yet the condvar wait ended. This should be unreachable."))
 	}
 }
 

--- a/src/platform/osx.rs
+++ b/src/platform/osx.rs
@@ -128,9 +128,8 @@ impl Clipboard {
 			// XXX: We explicitly use `pasteboardItems` and not `stringForType` since the latter will concat
 			// multiple strings, if present, into one and return it instead of reading just the first which is `arboard`'s
 			// historical behavior.
-			let contents = unsafe { self.pasteboard.pasteboardItems() }.ok_or_else(|| {
-				Error::Unknown { description: String::from("NSPasteboard#pasteboardItems errored") }
-			})?;
+			let contents = unsafe { self.pasteboard.pasteboardItems() }
+				.ok_or_else(|| Error::unknown("NSPasteboard#pasteboardItems errored"))?;
 
 			for item in contents {
 				if let Some(string) = unsafe { item.stringForType(type_) } {
@@ -262,7 +261,7 @@ impl<'clipboard> Set<'clipboard> {
 		if success {
 			Ok(())
 		} else {
-			Err(Error::Unknown { description: "NSPasteboard#writeObjects: returned false".into() })
+			Err(Error::unknown("NSPasteboard#writeObjects: returned false"))
 		}
 	}
 
@@ -296,7 +295,7 @@ impl<'clipboard> Set<'clipboard> {
 		if success {
 			Ok(())
 		} else {
-			Err(Error::Unknown { description: "NSPasteboard#writeObjects: returned false".into() })
+			Err(Error::unknown("NSPasteboard#writeObjects: returned false"))
 		}
 	}
 
@@ -315,11 +314,9 @@ impl<'clipboard> Set<'clipboard> {
 		if success {
 			Ok(())
 		} else {
-			Err(Error::Unknown {
-				description:
-					"Failed to write the image to the pasteboard (`writeObjects` returned NO)."
-						.into(),
-			})
+			Err(Error::unknown(
+				"Failed to write the image to the pasteboard (`writeObjects` returned NO).",
+			))
 		}
 	}
 }


### PR DESCRIPTION
Unsure why this method wasn't used more, just code cleanup.