### PR TITLE
add `file_list` to `Set` interface

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ env_logger = "0.10.2"
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = ">=0.52.0, <0.60.0", features = [
     "Win32_Foundation",
-    "Win32_Globalization",
+    "Win32_Storage_FileSystem",
     "Win32_System_DataExchange",
     "Win32_System_Memory",
     "Win32_System_Ole",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ wayland-data-control = ["wl-clipboard-rs"]
 
 # For backwards compat
 core-graphics = ["dep:objc2-core-graphics"]
-windows-sys = ["dep:windows-sys"]
+windows-sys = ["windows-sys/Win32_Graphics_Gdi"]
 image = ["dep:image"]
 wl-clipboard-rs = ["dep:wl-clipboard-rs"]
 
@@ -32,12 +32,13 @@ wl-clipboard-rs = ["dep:wl-clipboard-rs"]
 env_logger = "0.10.2"
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = ">=0.52.0, <0.60.0", optional = true, features = [
+windows-sys = { version = ">=0.52.0, <0.60.0", features = [
     "Win32_Foundation",
-    "Win32_Graphics_Gdi",
+    "Win32_Globalization",
     "Win32_System_DataExchange",
     "Win32_System_Memory",
     "Win32_System_Ole",
+    "Win32_UI_Shell",
 ] }
 clipboard-win = { version = "5.3.1", features = ["std"] }
 log = "0.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -243,6 +243,11 @@ impl Set<'_> {
 	pub fn image(self, image: ImageData) -> Result<(), Error> {
 		self.platform.image(image)
 	}
+
+	/// Completes the "set" operation by placing a list of file paths onto the clipboard.
+	pub fn file_list(self, file_list: Vec<String>) -> Result<(), Error> {
+		self.platform.file_list(&file_list)
+	}
 }
 
 /// A builder for an operation that clears the data from the clipboard.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,10 @@ and conditions of the chosen license apply to this file.
 #![warn(unreachable_pub)]
 
 mod common;
-use std::{borrow::Cow, path::PathBuf};
+use std::{
+	borrow::Cow,
+	path::{Path, PathBuf},
+};
 
 pub use common::Error;
 #[cfg(feature = "image-data")]
@@ -245,8 +248,8 @@ impl Set<'_> {
 	}
 
 	/// Completes the "set" operation by placing a list of file paths onto the clipboard.
-	pub fn file_list(self, file_list: Vec<String>) -> Result<(), Error> {
-		self.platform.file_list(&file_list)
+	pub fn file_list(self, file_list: &[impl AsRef<Path>]) -> Result<(), Error> {
+		self.platform.file_list(file_list)
 	}
 }
 
@@ -354,6 +357,19 @@ mod tests {
 			} else {
 				assert_eq!(ctx.get().html().unwrap(), html);
 			}
+		}
+		{
+			let mut ctx = Clipboard::new().unwrap();
+
+			let this_dir = env!("CARGO_MANIFEST_DIR");
+
+			let paths = &[
+				PathBuf::from(this_dir).join("README.md"),
+				PathBuf::from(this_dir).join("Cargo.toml"),
+			];
+
+			ctx.set().file_list(paths).unwrap();
+			assert_eq!(ctx.get().file_list().unwrap().as_slice(), paths);
 		}
 		#[cfg(feature = "image-data")]
 		{

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -1,8 +1,12 @@
-use std::{borrow::Cow, path::PathBuf, time::Instant};
+use std::{
+	borrow::Cow,
+	path::{Path, PathBuf},
+	time::Instant,
+};
 
 #[cfg(feature = "wayland-data-control")]
 use log::{trace, warn};
-use percent_encoding::percent_decode;
+use percent_encoding::{percent_decode, utf8_percent_encode, AsciiSet, CONTROLS};
 
 #[cfg(feature = "image-data")]
 use crate::ImageData;
@@ -50,6 +54,39 @@ fn paths_from_uri_list(uri_list: Vec<u8>) -> Vec<PathBuf> {
 		.filter_map(|s| percent_decode(s).decode_utf8().ok())
 		.map(|decoded| PathBuf::from(decoded.as_ref()))
 		.collect()
+}
+
+fn paths_to_uri_list(file_list: &[impl AsRef<Path>]) -> Result<String, Error> {
+	// The characters that require encoding, which includes £ and € but they can't be added to the set.
+	const ASCII_SET: &AsciiSet = &CONTROLS
+		.add(b'#')
+		.add(b';')
+		.add(b'?')
+		.add(b'[')
+		.add(b']')
+		.add(b' ')
+		.add(b'\"')
+		.add(b'%')
+		.add(b'<')
+		.add(b'>')
+		.add(b'\\')
+		.add(b'^')
+		.add(b'`')
+		.add(b'{')
+		.add(b'|')
+		.add(b'}');
+
+	file_list
+		.iter()
+		.filter_map(|path| {
+			path.as_ref().canonicalize().ok().and_then(|abs_path| {
+				abs_path
+					.to_str()
+					.map(|str| format!("file://{}", utf8_percent_encode(str, ASCII_SET)))
+			})
+		})
+		.reduce(|uri_list, uri| uri_list + "\n" + &uri)
+		.ok_or(Error::ConversionFailure)
 }
 
 /// Clipboard selection
@@ -237,6 +274,19 @@ impl<'clipboard> Set<'clipboard> {
 			#[cfg(feature = "wayland-data-control")]
 			Clipboard::WlDataControl(clipboard) => {
 				clipboard.set_image(image, self.selection, self.wait, self.exclude_from_history)
+			}
+		}
+	}
+
+	pub(crate) fn file_list(self, file_list: &[impl AsRef<Path>]) -> Result<(), Error> {
+		match self.clipboard {
+			Clipboard::X11(clipboard) => {
+				clipboard.set_file_list(file_list, self.selection, self.wait)
+			}
+
+			#[cfg(feature = "wayland-data-control")]
+			Clipboard::WlDataControl(clipboard) => {
+				clipboard.set_file_list(file_list, self.selection, self.wait)
 			}
 		}
 	}

--- a/src/platform/linux/wayland.rs
+++ b/src/platform/linux/wayland.rs
@@ -1,4 +1,8 @@
-use std::{borrow::Cow, io::Read, path::PathBuf};
+use std::{
+	borrow::Cow,
+	io::Read,
+	path::{Path, PathBuf},
+};
 
 use wl_clipboard_rs::{
 	copy::{self, Error as CopyError, MimeSource, MimeType, Options, Source},
@@ -9,8 +13,8 @@ use wl_clipboard_rs::{
 #[cfg(feature = "image-data")]
 use super::encode_as_png;
 use super::{
-	into_unknown, paths_from_uri_list, LinuxClipboardKind, WaitConfig, KDE_EXCLUSION_HINT,
-	KDE_EXCLUSION_MIME,
+	into_unknown, paths_from_uri_list, paths_to_uri_list, LinuxClipboardKind, WaitConfig,
+	KDE_EXCLUSION_HINT, KDE_EXCLUSION_MIME,
 };
 use crate::common::Error;
 #[cfg(feature = "image-data")]
@@ -231,5 +235,24 @@ impl Clipboard {
 		handle_clipboard_read(selection, paste::MimeType::Specific("text/uri-list"), |contents| {
 			Ok(paths_from_uri_list(contents))
 		})
+	}
+
+	pub(crate) fn set_file_list(
+		&self,
+		file_list: &[impl AsRef<Path>],
+		selection: LinuxClipboardKind,
+		wait: WaitConfig,
+	) -> Result<(), Error> {
+		let files = paths_to_uri_list(file_list)?;
+		let uri_mime = MimeType::Specific(String::from("text/uri-list"));
+		let mut opts = Options::new();
+		opts.foreground(matches!(wait, WaitConfig::Forever));
+		opts.clipboard(selection.try_into()?);
+		let source = Source::Bytes(files.into_bytes().into_boxed_slice());
+		opts.copy(source, uri_mime).map_err(|e| match e {
+			CopyError::PrimarySelectionUnsupported => Error::ClipboardNotSupported,
+			other => into_unknown(other),
+		})?;
+		Ok(())
 	}
 }

--- a/src/platform/linux/x11.rs
+++ b/src/platform/linux/x11.rs
@@ -16,7 +16,7 @@ use std::{
 	borrow::Cow,
 	cell::RefCell,
 	collections::{hash_map::Entry, HashMap},
-	path::PathBuf,
+	path::{Path, PathBuf},
 	sync::{
 		atomic::{AtomicBool, Ordering},
 		Arc,
@@ -46,8 +46,8 @@ use x11rb::{
 #[cfg(feature = "image-data")]
 use super::encode_as_png;
 use super::{
-	into_unknown, paths_from_uri_list, LinuxClipboardKind, WaitConfig, KDE_EXCLUSION_HINT,
-	KDE_EXCLUSION_MIME,
+	into_unknown, paths_from_uri_list, paths_to_uri_list, LinuxClipboardKind, WaitConfig,
+	KDE_EXCLUSION_HINT, KDE_EXCLUSION_MIME,
 };
 #[cfg(feature = "image-data")]
 use crate::ImageData;
@@ -1060,6 +1060,19 @@ impl Clipboard {
 		let result = self.inner.read(&[self.inner.atoms.URI_LIST], selection)?;
 
 		Ok(paths_from_uri_list(result.bytes))
+	}
+
+	pub(crate) fn set_file_list(
+		&self,
+		file_list: &[impl AsRef<Path>],
+		selection: LinuxClipboardKind,
+		wait: WaitConfig,
+	) -> Result<()> {
+		let files = paths_to_uri_list(file_list)?;
+
+		let data =
+			vec![ClipboardData { bytes: files.into_bytes(), format: self.inner.atoms.URI_LIST }];
+		self.inner.write(data, selection, wait)
 	}
 }
 

--- a/src/platform/linux/x11.rs
+++ b/src/platform/linux/x11.rs
@@ -1067,11 +1067,14 @@ impl Clipboard {
 		file_list: &[impl AsRef<Path>],
 		selection: LinuxClipboardKind,
 		wait: WaitConfig,
+		exclude_from_history: bool,
 	) -> Result<()> {
 		let files = paths_to_uri_list(file_list)?;
+		let mut data = Vec::with_capacity(if exclude_from_history { 2 } else { 1 });
 
-		let data =
-			vec![ClipboardData { bytes: files.into_bytes(), format: self.inner.atoms.URI_LIST }];
+		data.push(ClipboardData { bytes: files.into_bytes(), format: self.inner.atoms.URI_LIST });
+		self.add_clipboard_exclusions(exclude_from_history, &mut data);
+
 		self.inner.write(data, selection, wait)
 	}
 }

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -702,6 +702,13 @@ impl<'clipboard> Set<'clipboard> {
 		image_data::add_cf_dibv5(open_clipboard, image)?;
 		Ok(())
 	}
+
+	pub(crate) fn file_list(self, file_list: &[impl AsRef<str>]) -> Result<(), Error> {
+		let _clipboard_assertion = self.clipboard?;
+
+		clipboard_win::raw::set_file_list(file_list)
+			.map_err(|e| Error::unknown(format!("Setting file list failed with error code: {e}")))
+	}
 }
 
 fn add_clipboard_exclusions(

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -530,7 +530,7 @@ impl Clipboard {
 		Ok(Self(()))
 	}
 
-	fn open(&mut self) -> Result<OpenClipboard, Error> {
+	fn open(&mut self) -> Result<OpenClipboard<'_>, Error> {
 		// Attempt to open the clipboard multiple times. On Windows, its common for something else to temporarily
 		// be using it during attempts.
 		//

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -719,7 +719,7 @@ impl<'clipboard> Set<'clipboard> {
 	pub(crate) fn file_list(self, file_list: &[impl AsRef<Path>]) -> Result<(), Error> {
 		const DROPFILES_HEADER_SIZE: usize = std::mem::size_of::<DROPFILES>();
 
-		let _clipboard_assertion = self.clipboard?;
+		let clipboard_assertion = self.clipboard?;
 
 		// https://learn.microsoft.com/en-us/windows/win32/shell/clipboard#cf_hdrop
 		// CF_HDROP consists of an STGMEDIUM structure that contains a global memory object.
@@ -772,11 +772,16 @@ impl<'clipboard> Set<'clipboard> {
 
 			if SetClipboardData(CF_HDROP.into(), h_global as HANDLE).failure() {
 				GlobalFree(h_global);
-				Err(last_error("SetClipboardData failed with error"))
-			} else {
-				Ok(())
+				return Err(last_error("SetClipboardData failed with error"));
 			}
 		}
+
+		add_clipboard_exclusions(
+			clipboard_assertion,
+			self.exclude_from_monitoring,
+			self.exclude_from_cloud,
+			self.exclude_from_history,
+		)
 	}
 }
 


### PR DESCRIPTION
We should decide what type of input we accept.
On windows `clipboard_win::raw::set_file_list` is used which has as parameter `&[impl AsRef<str>]` and doesn't check if the input is actually a path; on linux and osx the parameter is of type `&[impl AsRef<Path>]`  and `canonicalize()` is called so non existing paths get discarded