### PR TITLE
Allow Compilation on Android Termux via Conditional Compilation Fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,7 @@ image = { version = "0.25", optional = true, default-features = false, features 
     "tiff",
 ] }
 
-[target.'cfg(all(unix, not(any(target_os="macos", target_os="android", target_os="emscripten"))))'.dependencies]
+[target.'cfg(all(unix, not(any(target_os="macos", target_os="emscripten"))))'.dependencies]
 log = "0.4"
 x11rb = { version = "0.13" }
 wl-clipboard-rs = { version = "0.9.0", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ mod platform;
 
 #[cfg(all(
 	unix,
-	not(any(target_os = "macos", target_os = "android", target_os = "emscripten")),
+	not(any(target_os = "macos", target_os = "emscripten")),
 ))]
 pub use platform::{ClearExtLinux, GetExtLinux, LinuxClipboardKind, SetExtLinux};
 
@@ -392,7 +392,7 @@ mod tests {
 		}
 		#[cfg(all(
 			unix,
-			not(any(target_os = "macos", target_os = "android", target_os = "emscripten")),
+			not(any(target_os = "macos", target_os = "emscripten")),
 		))]
 		{
 			use crate::{LinuxClipboardKind, SetExtLinux};

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -1,8 +1,8 @@
-#[cfg(all(unix, not(any(target_os = "macos", target_os = "android", target_os = "emscripten"))))]
+#[cfg(all(unix, not(any(target_os = "macos", target_os = "emscripten"))))]
 mod linux;
 #[cfg(all(
 	unix,
-	not(any(target_os = "macos", target_os = "android", target_os = "emscripten"))
+	not(any(target_os = "macos", target_os = "emscripten"))
 ))]
 pub use linux::*;
 


### PR DESCRIPTION
This pull request updates the conditional compilation settings in Cargo.toml, src/lib.rs, and src/platform/mod.rs. By removing Android from the exclusion list, the arboard library (and dependent applications such as sendme) can now compile successfully in Termux environments on Android.

Please note that this change is intended solely to enable the software to compile on Termux. If full clipboard functionality is required on Termux, it can be implemented relatively easily since Termux provides its own clipboard API.