### PR TITLE
linux/x11: Don't stop worker thread if handling selection request fails

### DIFF
--- a/src/platform/linux/x11.rs
+++ b/src/platform/linux/x11.rs
@@ -764,7 +764,10 @@ fn serve_requests(context: Arc<Inner>) -> Result<(), Box<dyn std::error::Error>>
 					context.atom_name_dbg(event.target),
 				);
 				// Someone is requesting the clipboard content from us.
-				context.handle_selection_request(event).map_err(into_unknown)?;
+				if let Err(e) = context.handle_selection_request(event).map_err(into_unknown) {
+					error!("Failed to handle selection request: {e}");
+					continue;
+				}
 
 				// if we are in the progress of saving to the clipboard manager
 				// make sure we save that we have finished writing

--- a/src/platform/linux/x11.rs
+++ b/src/platform/linux/x11.rs
@@ -764,7 +764,7 @@ fn serve_requests(context: Arc<Inner>) -> Result<(), Box<dyn std::error::Error>>
 					context.atom_name_dbg(event.target),
 				);
 				// Someone is requesting the clipboard content from us.
-				if let Err(e) = context.handle_selection_request(event).map_err(into_unknown) {
+				if let Err(e) = context.handle_selection_request(event) {
 					error!("Failed to handle selection request: {e}");
 					continue;
 				}


### PR DESCRIPTION
Just because one request fails, that doesn't mean we can't handle subsequent requests.
Stopping the worker thread on failure means that every subsequent request will fail, which is usually undesirable.

# Unresolved questions

I don't know if this has any undesirable side effects, since I'm not an X11/clipboard expert.
This requires careful review.

- [ ] Should we have some kind of way to programmatically get the error, rather than logging it?