### PR TITLE
Support windows-sys 0.60 in arboard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,9 +118,9 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.10"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
  "windows-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ wl-clipboard-rs = ["dep:wl-clipboard-rs"]
 env_logger = "0.10.2"
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = ">=0.52.0, <0.60.0", features = [
+windows-sys = { version = ">=0.52.0, <0.61.0", features = [
     "Win32_Foundation",
     "Win32_Storage_FileSystem",
     "Win32_System_DataExchange",


### PR DESCRIPTION
This PR supersedes #200 and adds semver compatibility for [windows-sys 0.60.x](https://crates.io/crates/windows-sys/0.60.2).

The existing GitHub action that checks the multi-version compatibility should correctly work here. We already know 0.59 works (and that release series is now deprecated), so there's no need to introduce an additional step to perform `0.59` -> `0.60` checking independently.

I had to update `errno` to allow `cargo update -p windows-sys` to reach `0.60` instead of stopping at `0.59` still. I verified this correct update behavior locally as well:

```
 cargo update -p windows-sys
    Updating crates.io index
     Locking 12 packages to latest compatible versions
      Adding windows-link v0.1.3
      Adding windows-sys v0.59.0
      Adding windows-sys v0.60.2
      Adding windows-targets v0.53.3
      Adding windows_aarch64_gnullvm v0.53.0
      Adding windows_aarch64_msvc v0.53.0
      Adding windows_i686_gnu v0.53.0
      Adding windows_i686_gnullvm v0.53.0
      Adding windows_i686_msvc v0.53.0
      Adding windows_x86_64_gnu v0.53.0
      Adding windows_x86_64_gnullvm v0.53.0
      Adding windows_x86_64_msvc v0.53.0
```

```
 cargo clippy --all-features
    Blocking waiting for file lock on build directory
    Checking windows_x86_64_msvc v0.53.0
    Checking windows-targets v0.53.3
    Checking windows-sys v0.60.2
    Checking arboard v3.6.0 (github\arboard)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2.73s
```