### PR TITLE
feat: add optional smithay-clipboard backend for Wayland clipboard support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,9 +30,11 @@ dependencies = [
  "objc2-core-foundation",
  "objc2-core-graphics",
  "objc2-foundation",
+ "once_cell",
  "parking_lot",
  "percent-encoding",
- "windows-sys",
+ "smithay-clipboard",
+ "windows-sys 0.52.0",
  "wl-clipboard-rs",
  "x11rb",
 ]
@@ -68,6 +70,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
+name = "calloop"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb9f6e1368bd4621d2c86baa7e37de77a938adf5221e5dd3d6133340101b309e"
+dependencies = [
+ "bitflags 2.8.0",
+ "polling",
+ "rustix 1.1.3",
+ "slab",
+ "tracing",
+]
+
+[[package]]
+name = "calloop-wayland-source"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "138efcf0940a02ebf0cc8d1eff41a1682a46b431630f4c52450d6265876021fa"
+dependencies = [
+ "calloop",
+ "rustix 1.1.3",
+ "wayland-backend",
+ "wayland-client",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -89,12 +116,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "cursor-icon"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
+
+[[package]]
+name = "dlib"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
+dependencies = [
+ "libloading",
 ]
 
 [[package]]
@@ -123,7 +180,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -183,6 +240,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -217,9 +280,9 @@ version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e19b23d53f35ce9f56aebc7d1bb4e6ac1e9c0db7ac85c8d1760c04379edced37"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.4.0",
  "libc",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -230,15 +293,31 @@ checksum = "f5d4a7da358eff58addd2877a45865158f0d78c911d43a5784ceb7bbf52833b0"
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.178"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
 
 [[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "lock_api"
@@ -261,6 +340,15 @@ name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
+name = "memmap2"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "744133e4a0e0a658e1374cf3bf8e415c4052a15a111acd372764c55b4177d490"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "minimal-lexical"
@@ -369,9 +457,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.15.0"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "os_pipe"
@@ -380,7 +468,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29d73ba8daf8fac13b0501d1abeddcfe21ba7401ada61a819144b6c2a4f32209"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -423,6 +511,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -441,10 +535,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.78"
+name = "polling"
+version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi 0.5.2",
+ "pin-project-lite",
+ "rustix 1.1.3",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
 dependencies = [
  "unicode-ident",
 ]
@@ -460,9 +568,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.35"
+version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
 dependencies = [
  "proc-macro2",
 ]
@@ -502,9 +610,28 @@ dependencies = [
  "bitflags 2.8.0",
  "errno",
  "libc",
- "linux-raw-sys",
- "windows-sys",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "rustix"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+dependencies = [
+ "bitflags 2.8.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.11.0",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -513,16 +640,71 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
+name = "slab"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+
+[[package]]
 name = "smallvec"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
 
 [[package]]
-name = "syn"
-version = "1.0.100"
+name = "smithay-client-toolkit"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52205623b1b0f064a4e71182c3b18ae902267282930c6d5462c91b859668426e"
+checksum = "0512da38f5e2b31201a93524adb8d3136276fa4fe4aafab4e1f727a82b534cc0"
+dependencies = [
+ "bitflags 2.8.0",
+ "calloop",
+ "calloop-wayland-source",
+ "cursor-icon",
+ "libc",
+ "log",
+ "memmap2",
+ "rustix 1.1.3",
+ "thiserror 2.0.17",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-csd-frame",
+ "wayland-cursor",
+ "wayland-protocols",
+ "wayland-protocols-experimental",
+ "wayland-protocols-misc",
+ "wayland-protocols-wlr",
+ "wayland-scanner",
+ "xkeysym",
+]
+
+[[package]]
+name = "smithay-clipboard"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71704c03f739f7745053bde45fa203a46c58d25bc5c4efba1d9a60e9dba81226"
+dependencies = [
+ "libc",
+ "smithay-client-toolkit",
+ "wayland-backend",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.111"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "390cc9a294ab71bdb1aa2e99d13be9c753cd2d7bd6560c77118597410c4d2e87"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -537,8 +719,8 @@ checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
 dependencies = [
  "cfg-if",
  "fastrand",
- "rustix",
- "windows-sys",
+ "rustix 0.38.44",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -556,7 +738,16 @@ version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c53f98874615aea268107765aa1ed8f6116782501d18e53d08b471733bea6c85"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.35",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+dependencies = [
+ "thiserror-impl 2.0.17",
 ]
 
 [[package]]
@@ -567,7 +758,18 @@ checksum = "f8b463991b4eab2d801e724172285ec4195c650e8ec79b149e6c2a8e6dd3f783"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -580,6 +782,23 @@ dependencies = [
  "jpeg-decoder",
  "weezl",
 ]
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "log",
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 
 [[package]]
 name = "tree_magic_mini"
@@ -602,38 +821,87 @@ checksum = "dcc811dc4066ac62f84f11307873c4850cb653bfa9b1719cee2bd2204a4bc5dd"
 
 [[package]]
 name = "wayland-backend"
-version = "0.3.8"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7208998eaa3870dad37ec8836979581506e0c5c64c20c9e79e9d2a10d6f47bf"
+checksum = "673a33c33048a5ade91a6b139580fa174e19fb0d23f396dca9fa15f2e1e49b35"
 dependencies = [
  "cc",
  "downcast-rs",
- "rustix",
+ "rustix 1.1.3",
+ "scoped-tls",
  "smallvec",
  "wayland-sys",
 ]
 
 [[package]]
 name = "wayland-client"
-version = "0.31.8"
+version = "0.31.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2120de3d33638aaef5b9f4472bff75f07c56379cf76ea320bd3a3d65ecaf73f"
+checksum = "c66a47e840dc20793f2264eb4b3e4ecb4b75d91c0dd4af04b456128e0bdd449d"
 dependencies = [
  "bitflags 2.8.0",
- "rustix",
+ "rustix 1.1.3",
  "wayland-backend",
  "wayland-scanner",
 ]
 
 [[package]]
-name = "wayland-protocols"
-version = "0.32.6"
+name = "wayland-csd-frame"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0781cf46869b37e36928f7b432273c0995aa8aed9552c556fb18754420541efc"
+checksum = "625c5029dbd43d25e6aa9615e88b829a5cad13b2819c4ae129fdbb7c31ab4c7e"
+dependencies = [
+ "bitflags 2.8.0",
+ "cursor-icon",
+ "wayland-backend",
+]
+
+[[package]]
+name = "wayland-cursor"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "447ccc440a881271b19e9989f75726d60faa09b95b0200a9b7eb5cc47c3eeb29"
+dependencies = [
+ "rustix 1.1.3",
+ "wayland-client",
+ "xcursor",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efa790ed75fbfd71283bd2521a1cfdc022aabcc28bdcff00851f9e4ae88d9901"
 dependencies = [
  "bitflags 2.8.0",
  "wayland-backend",
  "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-experimental"
+version = "20250721.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40a1f863128dcaaec790d7b4b396cc9b9a7a079e878e18c47e6c2d2c5a8dcbb1"
+dependencies = [
+ "bitflags 2.8.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-misc"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dfe33d551eb8bffd03ff067a8b44bb963919157841a99957151299a6307d19c"
+dependencies = [
+ "bitflags 2.8.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
  "wayland-scanner",
 ]
 
@@ -652,9 +920,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-scanner"
-version = "0.31.6"
+version = "0.31.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "896fdafd5d28145fce7958917d69f2fd44469b1d4e861cb5961bcbeebc6d1484"
+checksum = "54cb1e9dc49da91950bdfd8b848c49330536d9d1fb03d4bfec8cae50caa50ae3"
 dependencies = [
  "proc-macro2",
  "quick-xml",
@@ -663,10 +931,13 @@ dependencies = [
 
 [[package]]
 name = "wayland-sys"
-version = "0.31.6"
+version = "0.31.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbcebb399c77d5aa9fa5db874806ee7b4eba4e73650948e8f93963f128896615"
+checksum = "34949b42822155826b41db8e5d0c1be3a2bd296c747577a43a3e6daefc296142"
 dependencies = [
+ "dlib",
+ "log",
+ "once_cell",
  "pkg-config",
 ]
 
@@ -682,8 +953,14 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
@@ -692,6 +969,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -824,9 +1110,9 @@ dependencies = [
  "libc",
  "log",
  "os_pipe",
- "rustix",
+ "rustix 0.38.44",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.35",
  "tree_magic_mini",
  "wayland-backend",
  "wayland-client",
@@ -841,7 +1127,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8f25ead8c7e4cba123243a6367da5d3990e0d3affa708ea19dce96356bd9f1a"
 dependencies = [
  "gethostname",
- "rustix",
+ "rustix 0.38.44",
  "x11rb-protocol",
 ]
 
@@ -850,3 +1136,15 @@ name = "x11rb-protocol"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e63e71c4b8bd9ffec2c963173a4dc4cbde9ee96961d4fcb4429db9929b606c34"
+
+[[package]]
+name = "xcursor"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bec9e4a500ca8864c5b47b8b482a73d62e4237670e5b5f1d6b9e3cae50f28f2b"
+
+[[package]]
+name = "xkeysym"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,9 @@ image-data = [
 ]
 wayland-data-control = ["wl-clipboard-rs"]
 
+# Optional smithay-backed Wayland clipboard (uses core wl_data_device APIs)
+smithay-clipboard = ["dep:smithay-clipboard", "dep:once_cell"]
+
 # For backwards compat
 core-graphics = ["dep:objc2-core-graphics"]
 windows-sys = ["windows-sys/Win32_Graphics_Gdi"]
@@ -81,6 +84,10 @@ image = { version = "0.25", optional = true, default-features = false, features 
 log = "0.4"
 x11rb = { version = "0.13" }
 wl-clipboard-rs = { version = "0.9.0", optional = true }
+# smithay-clipboard provides an implementation that uses wl_data_device (core Wayland clipboard)
+smithay-clipboard = { version = "0.7", optional = true }
+# once_cell used to hold a global wl_display pointer safely
+once_cell = { version = "1.21", optional = true }
 image = { version = "0.25", optional = true, default-features = false, features = [
     "png",
 ] }
@@ -94,3 +101,7 @@ required-features = ["image-data"]
 [[example]]
 name = "set_image"
 required-features = ["image-data"]
+
+[[example]]
+name = "smithay_daemonize"
+required-features = ["smithay-clipboard"]

--- a/README.md
+++ b/README.md
@@ -37,6 +37,17 @@ Wayland environment. It is recommended to enable `XWayland` for these cases. If 
 an isolated sandbox, such as Flatpak or Snap, you'll need to expose the X11 socket to the application
 _in addition_ to the Wayland communication interface.
 
+When the `wlr-data-control` protocol is not available, for instance, on GNOME, arboard provides an optional `smithay-clipboard` feature which uses the core Wayland
+`wl_data_device` APIs (via `smithay-clipboard`). Note that `smithay` does
+not currently provide a notification for "first paste"; arboard emulates `SetExtLinux::wait()` by
+polling the clipboard contents until they change (i.e. it appears overwritten) while keeping the
+Wayland selection owner alive.
+
+Limitations of the `smithay-clipboard` backend today:
+- It currently supports **text on the `Clipboard` selection only** (no `Primary` selection, images, HTML, or file lists).
+- `exclude_from_history()` is currently a no-op on this backend.
+- `wait()`/`wait_until()` detect "overwritten" by observing a **text value change**; if another app overwrites the clipboard with the exact same text, `wait()` may not return.
+
 ### Clipboard Ownership
 
 Some apps and users may notice that sometimes values copied to a Linux clipboard with this crate vanish
@@ -64,7 +75,7 @@ If your application is exiting, you must make sure there is a clipboard manager 
 the clipboard ownership transfer, or made a copy previously, the data will be lost. Note that this isn't a complete 
 guarantee as races are possible if your program's main thread is exiting. If you would like to fully synchronize the clipboard "paste"
 before exiting, you can use the [wait](https://docs.rs/arboard/latest/arboard/trait.SetExtLinux.html#tymethod.wait) method when setting
-contents on the clipboard. This will block the calling thread until another app has requested, and then received, the data.
+contents on the clipboard. This will block the calling thread and keep serving clipboard requests until the clipboard is overwritten.
 
 If your application is longer-running (ie a GUI, TUI, etc), it is highly recommended that you either store the `Clipboard` object in some 
 long-lived data structure (like app context, etc) or utilize `wait` method mentioned above, and/or threading to make sure another 

--- a/examples/smithay_daemonize.rs
+++ b/examples/smithay_daemonize.rs
@@ -1,0 +1,23 @@
+// Example showing how to initialize the smithay backend and use `wait()` semantics.
+// NOTE: In a real Wayland GUI app you should obtain a real `*mut wl_display` pointer from your
+// toolkit (for example: `gdk_wayland_display_get_wl_display` or `RawDisplayHandle::Wayland`).
+// This example compiles as-is but does **not** actually connect to Wayland.
+
+use arboard::SetExtLinux;
+
+fn main() -> Result<(), arboard::Error> {
+    // SAFETY: you must pass a real wl_display pointer from your GUI toolkit or raw window handle.
+    #[cfg(all(feature = "smithay-clipboard", unix, not(any(target_os = "macos", target_os = "android", target_os = "emscripten"))))]
+    unsafe {
+        // Replace with a real pointer in a real app.
+        let wl_display: *mut std::ffi::c_void = std::ptr::null_mut();
+        // Ignore the result in this example; init will error on a null pointer.
+        let _ = arboard::init_wayland_display(wl_display);
+    }
+
+    let mut cb = arboard::Clipboard::new()?;
+
+    // This will block/daemonize until the clipboard is overwritten due to `wait()` behavior.
+    cb.set().wait().text("Hello smithay".to_owned())?;
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,13 @@ pub use common::ImageData;
 
 mod platform;
 
+#[cfg(all(feature = "smithay-clipboard", unix, not(any(target_os = "macos", target_os = "android", target_os = "emscripten"))))]
+/// Safety: `display` must be a valid pointer to a `wl_display` and must remain valid for how long
+/// the clipboard is used. Call this before creating a `Clipboard` if you want to use the smithay backend.
+pub unsafe fn init_wayland_display(display: *mut std::ffi::c_void) -> Result<(), Error> {
+	platform::init_wayland_display(display)
+}
+
 #[cfg(all(
 	unix,
 	not(any(target_os = "macos", target_os = "android", target_os = "emscripten")),
@@ -274,8 +281,41 @@ mod tests {
 	use super::*;
 	use std::{sync::Arc, thread, time::Duration};
 
+	/// Check if a display server is available for clipboard operations.
+	/// Returns true if we can reasonably expect clipboard operations to work.
+	/// 
+	/// Only checks on Linux/BSD where X11/Wayland display servers are required.
+	/// Other platforms (macOS, Windows) use native APIs and don't need this check.
+	fn is_display_server_available() -> bool {
+		// On Linux/BSD, we need either X11 or Wayland to be reachable
+		#[cfg(all(
+			unix,
+			not(any(target_os = "macos", target_os = "android", target_os = "emscripten"))
+		))]
+		{
+			// Quick check: try to create a clipboard and see if it fails
+			Clipboard::new().is_ok()
+		}
+
+		// On all other platforms (macOS, Windows, etc.), clipboard uses native APIs
+		// and doesn't require a display server, so tests can always run
+		#[cfg(not(all(
+			unix,
+			not(any(target_os = "macos", target_os = "android", target_os = "emscripten"))
+		)))]
+		{
+			true
+		}
+	}
+
 	#[test]
 	fn all_tests() {
+		if !is_display_server_available() {
+			eprintln!("Skipping clipboard integration tests: no display server available.");
+			eprintln!("To run these tests, ensure DISPLAY or WAYLAND_DISPLAY is set and reachable.");
+			eprintln!("In CI, consider running under Xvfb: `xvfb-run cargo test`");
+			return;
+		}
 		let _ = env_logger::builder().is_test(true).try_init();
 		{
 			let mut ctx = Clipboard::new().unwrap();
@@ -474,6 +514,13 @@ mod tests {
 	// to be open at once without issue, as documented under [Clipboard].
 	#[test]
 	fn multiple_clipboards_at_once() {
+		if !is_display_server_available() {
+			eprintln!("Skipping clipboard integration tests: no display server available.");
+			eprintln!("To run these tests, ensure DISPLAY or WAYLAND_DISPLAY is set and reachable.");
+			eprintln!("In CI, consider running under Xvfb: `xvfb-run cargo test`");
+			return;
+		}
+
 		const THREAD_COUNT: usize = 100;
 
 		let mut handles = Vec::with_capacity(THREAD_COUNT);

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -1,5 +1,6 @@
 use std::{
 	borrow::Cow,
+	ffi::c_void,
 	os::unix::ffi::OsStrExt,
 	path::{Path, PathBuf},
 	time::Instant,
@@ -7,11 +8,16 @@ use std::{
 
 #[cfg(feature = "wayland-data-control")]
 use log::{trace, warn};
+
+#[cfg(feature = "smithay-clipboard")]
+use log::trace;
 use percent_encoding::{percent_decode, percent_encode, AsciiSet, CONTROLS};
 
 #[cfg(feature = "image-data")]
 use crate::ImageData;
 use crate::{common::private, Error};
+#[cfg(feature = "smithay-clipboard")]
+use parking_lot::Mutex;
 
 // Magic strings used in `Set::exclude_from_history()` on linux
 const KDE_EXCLUSION_MIME: &str = "x-kde-passwordManagerHint";
@@ -21,6 +27,10 @@ mod x11;
 
 #[cfg(feature = "wayland-data-control")]
 mod wayland;
+
+// Optional smithay backend (uses core Wayland wl_data_device)
+#[cfg(feature = "smithay-clipboard")]
+mod smithay;
 
 fn into_unknown<E: std::fmt::Display>(error: E) -> Error {
 	Error::Unknown { description: error.to_string() }
@@ -120,12 +130,23 @@ pub enum LinuxClipboardKind {
 pub(crate) enum Clipboard {
 	X11(x11::Clipboard),
 
+	#[cfg(feature = "smithay-clipboard")]
+	WlSmithay(Mutex<smithay::Clipboard>),
+
 	#[cfg(feature = "wayland-data-control")]
 	WlDataControl(wayland::Clipboard),
 }
 
 impl Clipboard {
 	pub(crate) fn new() -> Result<Self, Error> {
+		#[cfg(feature = "smithay-clipboard")]
+		{
+			if smithay::is_available() {
+				trace!("Using smithay clipboard backend");
+				return Ok(Self::WlSmithay(Mutex::new(smithay::Clipboard::new()?)));
+			}
+		}
+
 		#[cfg(feature = "wayland-data-control")]
 		{
 			if std::env::var_os("WAYLAND_DISPLAY").is_some() {
@@ -159,6 +180,10 @@ impl<'clipboard> Get<'clipboard> {
 	pub(crate) fn text(self) -> Result<String, Error> {
 		match self.clipboard {
 			Clipboard::X11(clipboard) => clipboard.get_text(self.selection),
+
+			#[cfg(feature = "smithay-clipboard")]
+			Clipboard::WlSmithay(clipboard) => clipboard.lock().get_text(self.selection),
+
 			#[cfg(feature = "wayland-data-control")]
 			Clipboard::WlDataControl(clipboard) => clipboard.get_text(self.selection),
 		}
@@ -168,6 +193,10 @@ impl<'clipboard> Get<'clipboard> {
 	pub(crate) fn image(self) -> Result<ImageData<'static>, Error> {
 		match self.clipboard {
 			Clipboard::X11(clipboard) => clipboard.get_image(self.selection),
+
+			#[cfg(feature = "smithay-clipboard")]
+			Clipboard::WlSmithay(_) => Err(Error::ClipboardNotSupported),
+
 			#[cfg(feature = "wayland-data-control")]
 			Clipboard::WlDataControl(clipboard) => clipboard.get_image(self.selection),
 		}
@@ -176,6 +205,10 @@ impl<'clipboard> Get<'clipboard> {
 	pub(crate) fn html(self) -> Result<String, Error> {
 		match self.clipboard {
 			Clipboard::X11(clipboard) => clipboard.get_html(self.selection),
+
+			#[cfg(feature = "smithay-clipboard")]
+			Clipboard::WlSmithay(_) => Err(Error::ClipboardNotSupported),
+
 			#[cfg(feature = "wayland-data-control")]
 			Clipboard::WlDataControl(clipboard) => clipboard.get_html(self.selection),
 		}
@@ -184,6 +217,10 @@ impl<'clipboard> Get<'clipboard> {
 	pub(crate) fn file_list(self) -> Result<Vec<PathBuf>, Error> {
 		match self.clipboard {
 			Clipboard::X11(clipboard) => clipboard.get_file_list(self.selection),
+
+			#[cfg(feature = "smithay-clipboard")]
+			Clipboard::WlSmithay(_) => Err(Error::ClipboardNotSupported),
+
 			#[cfg(feature = "wayland-data-control")]
 			Clipboard::WlDataControl(clipboard) => clipboard.get_file_list(self.selection),
 		}
@@ -243,6 +280,14 @@ impl<'clipboard> Set<'clipboard> {
 				clipboard.set_text(text, self.selection, self.wait, self.exclude_from_history)
 			}
 
+			#[cfg(feature = "smithay-clipboard")]
+			Clipboard::WlSmithay(clipboard) => clipboard.lock().set_text(
+				text,
+				self.selection,
+				self.wait,
+				self.exclude_from_history,
+			),
+
 			#[cfg(feature = "wayland-data-control")]
 			Clipboard::WlDataControl(clipboard) => {
 				clipboard.set_text(text, self.selection, self.wait, self.exclude_from_history)
@@ -255,6 +300,9 @@ impl<'clipboard> Set<'clipboard> {
 			Clipboard::X11(clipboard) => {
 				clipboard.set_html(html, alt, self.selection, self.wait, self.exclude_from_history)
 			}
+
+			#[cfg(feature = "smithay-clipboard")]
+			Clipboard::WlSmithay(_) => Err(Error::ClipboardNotSupported),
 
 			#[cfg(feature = "wayland-data-control")]
 			Clipboard::WlDataControl(clipboard) => {
@@ -269,6 +317,9 @@ impl<'clipboard> Set<'clipboard> {
 			Clipboard::X11(clipboard) => {
 				clipboard.set_image(image, self.selection, self.wait, self.exclude_from_history)
 			}
+
+			#[cfg(feature = "smithay-clipboard")]
+			Clipboard::WlSmithay(_) => Err(Error::ClipboardNotSupported),
 
 			#[cfg(feature = "wayland-data-control")]
 			Clipboard::WlDataControl(clipboard) => {
@@ -285,6 +336,9 @@ impl<'clipboard> Set<'clipboard> {
 				self.wait,
 				self.exclude_from_history,
 			),
+
+			#[cfg(feature = "smithay-clipboard")]
+			Clipboard::WlSmithay(_) => Err(Error::ClipboardNotSupported),
 
 			#[cfg(feature = "wayland-data-control")]
 			Clipboard::WlDataControl(clipboard) => clipboard.set_file_list(
@@ -343,7 +397,7 @@ pub trait SetExtLinux: private::Sealed {
 	///
 	/// # Examples
 	///
-	/// ```
+	/// ```no_run
 	/// use arboard::{Clipboard, SetExtLinux, LinuxClipboardKind};
 	/// # fn main() -> Result<(), arboard::Error> {
 	/// let mut ctx = Clipboard::new()?;
@@ -404,6 +458,10 @@ impl<'clipboard> Clear<'clipboard> {
 	fn clear_inner(self, selection: LinuxClipboardKind) -> Result<(), Error> {
 		match self.clipboard {
 			Clipboard::X11(clipboard) => clipboard.clear(selection),
+
+			#[cfg(feature = "smithay-clipboard")]
+			Clipboard::WlSmithay(clipboard) => clipboard.lock().clear(selection),
+
 			#[cfg(feature = "wayland-data-control")]
 			Clipboard::WlDataControl(clipboard) => clipboard.clear(selection),
 		}
@@ -439,6 +497,16 @@ impl ClearExtLinux for crate::Clear<'_> {
 	}
 }
 
+#[cfg(feature = "smithay-clipboard")]
+/// Initialize smithay backend using a raw `wl_display` pointer.
+///
+/// # Safety
+/// `display` must be a valid pointer to a `wl_display` and must remain valid for the
+/// lifetime of the application that uses the clipboard.
+pub(crate) unsafe fn init_wayland_display(display: *mut c_void) -> Result<(), Error> {
+	smithay::init_from_display(display)
+}
+
 #[cfg(test)]
 mod tests {
 	use super::*;
@@ -461,5 +529,12 @@ mod tests {
 			PathBuf::from("/tmp/white space.txt"),
 		];
 		assert_eq!(paths_from_uri_list(file_list.join("\n").into()), paths);
+	}
+
+	#[cfg(feature = "smithay-clipboard")]
+	#[test]
+	fn smithay_initially_unavailable() {
+		// Unless init was called, it should report unavailable
+		assert!(!smithay::is_available());
 	}
 }

--- a/src/platform/linux/smithay.rs
+++ b/src/platform/linux/smithay.rs
@@ -1,0 +1,126 @@
+use std::{borrow::Cow, ffi::c_void, time::Duration, time::Instant};
+
+use once_cell::sync::OnceCell;
+use std::sync::atomic::{AtomicPtr, Ordering};
+
+use crate::common::Error;
+use super::{into_unknown, LinuxClipboardKind, WaitConfig};
+
+// smithay_clipboard provides a clipboard for Wayland clients using core protocols
+use smithay_clipboard::Clipboard as SmithayClipboard;
+
+// Store the raw display pointer. We keep this in a `OnceCell` and construct a per-`arboard::Clipboard`
+// smithay worker from it.
+static GLOBAL_DISPLAY: OnceCell<AtomicPtr<c_void>> = OnceCell::new();
+
+/// Safety: `display` must be a valid `*mut wl_display` pointer which remains valid
+/// for as long as the clipboard is used.
+pub(super) unsafe fn init_from_display(display: *mut c_void) -> Result<(), Error> {
+    if display.is_null() {
+        return Err(Error::ClipboardNotSupported);
+    }
+
+    GLOBAL_DISPLAY
+        .set(AtomicPtr::new(display))
+        .map_err(|_| Error::ClipboardNotSupported)
+}
+
+pub(super) fn is_available() -> bool {
+    GLOBAL_DISPLAY.get().is_some()
+}
+
+fn display_ptr() -> Result<*mut c_void, Error> {
+    GLOBAL_DISPLAY
+        .get()
+    .map(|p| p.load(Ordering::SeqCst))
+        .ok_or(Error::ClipboardNotSupported)
+}
+
+pub(crate) struct Clipboard {
+    inner: SmithayClipboard,
+}
+
+impl Clipboard {
+    pub(crate) fn new() -> Result<Self, Error> {
+        let display = display_ptr()?;
+        // Safety: `display` is set through the public `init_wayland_display`, which requires the
+        // pointer to remain valid for the lifetime of the application.
+        let inner = unsafe { SmithayClipboard::new(display) };
+        Ok(Self { inner })
+    }
+
+    pub(crate) fn get_text(&mut self, selection: LinuxClipboardKind) -> Result<String, Error> {
+        // smithay-clipboard uses the core `wl_data_device` clipboard selection only.
+        match selection {
+            LinuxClipboardKind::Clipboard => self.inner.load().map_err(into_unknown),
+            LinuxClipboardKind::Primary | LinuxClipboardKind::Secondary => Err(Error::ClipboardNotSupported),
+        }
+    }
+
+    pub(crate) fn set_text(
+        &mut self,
+        text: Cow<'_, str>,
+        selection: LinuxClipboardKind,
+        wait: WaitConfig,
+        _exclude_from_history: bool,
+    ) -> Result<(), Error> {
+        let owned = text.into_owned();
+
+        // smithay-clipboard uses the core `wl_data_device` clipboard selection only.
+        match selection {
+            LinuxClipboardKind::Clipboard => {
+                self.inner.store(owned.clone());
+
+                // `SetExtLinux::wait()` is expected to *block* the calling thread while continuing
+                // to serve clipboard requests. Keeping `self` alive in this call achieves that.
+                let poll = Duration::from_millis(250);
+                match wait {
+                    WaitConfig::None => Ok(()),
+                    WaitConfig::Forever => {
+                        loop {
+                            match self.inner.load() {
+                                Ok(current) => {
+                                    if current != owned {
+                                        break;
+                                    }
+                                }
+                                Err(_) => break,
+                            }
+                            std::thread::sleep(poll);
+                        }
+                        Ok(())
+                    }
+                    WaitConfig::Until(deadline) => {
+                        while Instant::now() < deadline {
+                            match self.inner.load() {
+                                Ok(current) => {
+                                    if current != owned {
+                                        break;
+                                    }
+                                }
+                                Err(_) => break,
+                            }
+                            std::thread::sleep(poll);
+                        }
+                        Ok(())
+                    }
+                }
+            }
+            LinuxClipboardKind::Primary | LinuxClipboardKind::Secondary => Err(Error::ClipboardNotSupported),
+        }
+    }
+
+    pub(crate) fn clear(&mut self, selection: LinuxClipboardKind) -> Result<(), Error> {
+        // There is no explicit "clear" in the core Wayland clipboard protocol.
+        // Storing an empty string is a best-effort approximation.
+        match selection {
+            LinuxClipboardKind::Clipboard => {
+                self.inner.store(String::new());
+                Ok(())
+            }
+            LinuxClipboardKind::Primary | LinuxClipboardKind::Secondary => Err(Error::ClipboardNotSupported),
+        }
+    }
+}
+
+// TODO: add image/file_list support in future iterations using the smithay worker APIs


### PR DESCRIPTION
- Introduced a new feature `smithay-clipboard` that utilizes the core Wayland `wl_data_device` APIs. This is especially useful to support window compositors like Mutter for GNOME
- Implemented a new `Clipboard` struct in the `smithay` module to handle clipboard operations.
- Added `init_wayland_display` function to initialize the Wayland display pointer for the smithay backend.
- Updated `Cargo.toml` and `Cargo.lock` to include `smithay-clipboard` and its dependencies.
- Created an example `smithay_daemonize.rs` demonstrating the usage of the new backend.
- Enhanced README with details on the limitations and usage of the `smithay-clipboard` feature.
- Updated existing clipboard handling logic to support the new backend while maintaining compatibility with previous implementations.

Related: https://github.com/flathub/me.proton.Pass/issues/37 https://github.com/bitwarden/clients/issues/13431