### PR TITLE
Properly encode/decode MIME=text/uri-list

### DIFF
--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -51,6 +51,7 @@ fn encode_as_png(image: &ImageData) -> Result<Vec<u8>, Error> {
 fn paths_from_uri_list(uri_list: Vec<u8>) -> Vec<PathBuf> {
 	uri_list
 		.split(|char| *char == b'\n')
+		.map(|line| line.strip_suffix(b"\r").unwrap_or(line))
 		.filter_map(|line| line.strip_prefix(b"file://"))
 		.filter_map(|s| percent_decode(s).decode_utf8().ok())
 		.map(|decoded| PathBuf::from(decoded.as_ref()))
@@ -84,7 +85,7 @@ fn paths_to_uri_list(file_list: &[impl AsRef<Path>]) -> Result<String, Error> {
 				format!("file://{}", percent_encode(path.as_os_str().as_bytes(), ASCII_SET))
 			})
 		})
-		.reduce(|uri_list, uri| uri_list + "\n" + &uri)
+		.reduce(|uri_list, uri| uri_list + "\r\n" + &uri)
 		.ok_or(Error::ConversionFailure)
 }
 
@@ -460,6 +461,6 @@ mod tests {
 			PathBuf::from("/tmp/foo?.png"),
 			PathBuf::from("/tmp/white space.txt"),
 		];
-		assert_eq!(paths_from_uri_list(file_list.join("\n").into()), paths);
+		assert_eq!(paths_from_uri_list(file_list.join("\r\n").into()), paths);
 	}
 }

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -85,6 +85,9 @@ fn paths_to_uri_list(file_list: &[impl AsRef<Path>]) -> Result<String, Error> {
 				format!("file://{}", percent_encode(path.as_os_str().as_bytes(), ASCII_SET))
 			})
 		})
+		// Use CRLF ("\r\n") per RFC 2045 section 2.10:
+		// https://www.rfc-editor.org/rfc/rfc2045#section-2.10
+		// Ensures compliance and future-proofing.
 		.reduce(|uri_list, uri| uri_list + "\r\n" + &uri)
 		.ok_or(Error::ConversionFailure)
 }


### PR DESCRIPTION
In all the text/* formats the lines are terminated with a CRLF pair.

Fixes #216
