### PR TITLE
increase windows-sys lower bound to 0.62

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ wl-clipboard-rs = ["dep:wl-clipboard-rs"]
 env_logger = "0.10.2"
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = ">=0.52.0, <0.61.0", features = [
+windows-sys = { version = ">=0.52.0, <0.62.0", features = [
     "Win32_Foundation",
     "Win32_Storage_FileSystem",
     "Win32_System_DataExchange",


### PR DESCRIPTION
it's required to de-duplicate windows-sys in [iced](https://github.com/iced-rs/iced). no functional change.