### PR TITLE
Support GNOME file clipboard format on Linux

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,11 +59,15 @@ jobs:
       - name: Run `cargo clippy` with all features
         run: cargo clippy --verbose --all-features -- -D warnings -D clippy::dbg_macro
 
+      - name: Run Linux clipboard format tests
+        if: ${{ matrix.os == 'ubuntu-latest' && matrix.rust_version == 'stable' }}
+        run: "cargo test --all-features platform::linux::tests::"
+
       - name: Run `cargo clippy` with dependency version checks
         if: ${{ matrix.rust_version == 'stable' }}
         run: |
           cargo update -p windows-sys
-          cargo clippy --verbose --all-features -- -D warnings -D clippy::dbg_macro 
+          cargo clippy --verbose --all-features -- -D warnings -D clippy::dbg_macro
 
   test:
     needs: clippy

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -202,6 +202,8 @@ impl Get<'_> {
 	}
 
 	/// Completes the "get" operation by fetching a list of file paths from the clipboard.
+	///
+	/// On Linux, this does not preserve whether the source marked the files for copying or cutting.
 	pub fn file_list(self) -> Result<Vec<PathBuf>, Error> {
 		self.platform.file_list()
 	}
@@ -248,6 +250,8 @@ impl Set<'_> {
 	}
 
 	/// Completes the "set" operation by placing a list of file paths onto the clipboard.
+	///
+	/// On Linux, the files are marked for copying.
 	pub fn file_list(self, file_list: &[impl AsRef<Path>]) -> Result<(), Error> {
 		self.platform.file_list(file_list)
 	}

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -17,6 +17,9 @@ use crate::{common::private, Error};
 const KDE_EXCLUSION_MIME: &str = "x-kde-passwordManagerHint";
 const KDE_EXCLUSION_HINT: &[u8] = b"secret";
 
+const URI_LIST_MIME: &str = "text/uri-list";
+const GNOME_COPIED_FILES_MIME: &str = "x-special/gnome-copied-files";
+
 mod x11;
 
 #[cfg(feature = "wayland-data-control")]
@@ -90,6 +93,12 @@ fn paths_to_uri_list(file_list: &[impl AsRef<Path>]) -> Result<String, Error> {
 		// Ensures compliance and future-proofing.
 		.reduce(|uri_list, uri| uri_list + "\r\n" + &uri)
 		.ok_or(Error::ConversionFailure)
+}
+
+fn gnome_copied_files_from_uri_list(uri_list: &str) -> Vec<u8> {
+	// GNOME's copied-files format uses an action header followed by LF-separated URIs:
+	// https://github.com/linuxmint/nemo/blob/29fbc4b00005234dd92624a5620cc644525ba27c/libnemo-private/nemo-clipboard-monitor.c#L218-L260
+	format!("copy\n{}", uri_list.replace("\r\n", "\n")).into_bytes()
 }
 
 /// Clipboard selection
@@ -465,5 +474,31 @@ mod tests {
 			PathBuf::from("/tmp/white space.txt"),
 		];
 		assert_eq!(paths_from_uri_list(file_list.join("\r\n").into()), paths);
+	}
+
+	#[test]
+	fn test_decoding_gnome_copied_files() {
+		let file_list = b"copy\nfile:///tmp/bar.log\nfile:///tmp/white%20space.txt";
+		let paths = vec![PathBuf::from("/tmp/bar.log"), PathBuf::from("/tmp/white space.txt")];
+
+		assert_eq!(paths_from_uri_list(file_list.to_vec()), paths);
+	}
+
+	#[test]
+	fn test_decoding_gnome_cut_files() {
+		let file_list = b"cut\nfile:///tmp/bar.log\nfile:///tmp/white%20space.txt";
+		let paths = vec![PathBuf::from("/tmp/bar.log"), PathBuf::from("/tmp/white space.txt")];
+
+		assert_eq!(paths_from_uri_list(file_list.to_vec()), paths);
+	}
+
+	#[test]
+	fn test_encoding_gnome_copied_files() {
+		let uri_list = "file:///tmp/bar.log\r\nfile:///tmp/white%20space.txt";
+
+		assert_eq!(
+			gnome_copied_files_from_uri_list(uri_list),
+			b"copy\nfile:///tmp/bar.log\nfile:///tmp/white%20space.txt"
+		);
 	}
 }

--- a/src/platform/linux/wayland.rs
+++ b/src/platform/linux/wayland.rs
@@ -13,8 +13,9 @@ use wl_clipboard_rs::{
 #[cfg(feature = "image-data")]
 use super::encode_as_png;
 use super::{
-	into_unknown, paths_from_uri_list, paths_to_uri_list, LinuxClipboardKind, WaitConfig,
-	KDE_EXCLUSION_HINT, KDE_EXCLUSION_MIME,
+	gnome_copied_files_from_uri_list, into_unknown, paths_from_uri_list, paths_to_uri_list,
+	LinuxClipboardKind, WaitConfig, GNOME_COPIED_FILES_MIME, KDE_EXCLUSION_HINT,
+	KDE_EXCLUSION_MIME, URI_LIST_MIME,
 };
 use crate::common::Error;
 #[cfg(feature = "image-data")]
@@ -22,8 +23,6 @@ use crate::common::ImageData;
 
 #[cfg(feature = "image-data")]
 const MIME_PNG: &str = "image/png";
-
-const MIME_URI: &str = "text/uri-list";
 
 pub(crate) struct Clipboard {}
 
@@ -234,9 +233,20 @@ impl Clipboard {
 		&mut self,
 		selection: LinuxClipboardKind,
 	) -> Result<Vec<PathBuf>, Error> {
-		handle_clipboard_read(selection, paste::MimeType::Specific(MIME_URI), |contents| {
-			Ok(paths_from_uri_list(contents))
-		})
+		let read_file_list = |contents| Ok(paths_from_uri_list(contents));
+		match handle_clipboard_read(
+			selection,
+			paste::MimeType::Specific(URI_LIST_MIME),
+			read_file_list,
+		) {
+			Ok(paths) => Ok(paths),
+			Err(Error::ContentNotAvailable) => handle_clipboard_read(
+				selection,
+				paste::MimeType::Specific(GNOME_COPIED_FILES_MIME),
+				|contents| Ok(paths_from_uri_list(contents)),
+			),
+			Err(error) => Err(error),
+		}
 	}
 
 	pub(crate) fn set_file_list(
@@ -247,15 +257,20 @@ impl Clipboard {
 		exclude_from_history: bool,
 	) -> Result<(), Error> {
 		let files = paths_to_uri_list(file_list)?;
+		let gnome_files = gnome_copied_files_from_uri_list(&files);
 
 		let mut opts = Options::new();
 		opts.foreground(matches!(wait, WaitConfig::Forever));
 		opts.clipboard(selection.try_into()?);
 
-		let mut sources = Vec::with_capacity(if exclude_from_history { 2 } else { 1 });
+		let mut sources = Vec::with_capacity(if exclude_from_history { 3 } else { 2 });
 		sources.push(MimeSource {
 			source: Source::Bytes(files.into_bytes().into_boxed_slice()),
-			mime_type: MimeType::Specific(String::from(MIME_URI)),
+			mime_type: MimeType::Specific(String::from(URI_LIST_MIME)),
+		});
+		sources.push(MimeSource {
+			source: Source::Bytes(gnome_files.into_boxed_slice()),
+			mime_type: MimeType::Specific(String::from(GNOME_COPIED_FILES_MIME)),
 		});
 
 		add_clipboard_exclusions(exclude_from_history, &mut sources);

--- a/src/platform/linux/x11.rs
+++ b/src/platform/linux/x11.rs
@@ -46,8 +46,9 @@ use x11rb::{
 #[cfg(feature = "image-data")]
 use super::encode_as_png;
 use super::{
-	into_unknown, paths_from_uri_list, paths_to_uri_list, LinuxClipboardKind, WaitConfig,
-	KDE_EXCLUSION_HINT, KDE_EXCLUSION_MIME,
+	gnome_copied_files_from_uri_list, into_unknown, paths_from_uri_list, paths_to_uri_list,
+	LinuxClipboardKind, WaitConfig, GNOME_COPIED_FILES_MIME, KDE_EXCLUSION_HINT,
+	KDE_EXCLUSION_MIME, URI_LIST_MIME,
 };
 #[cfg(feature = "image-data")]
 use crate::ImageData;
@@ -81,7 +82,8 @@ x11rb::atom_manager! {
 		TEXT_MIME_UNKNOWN: b"text/plain",
 
 		HTML: b"text/html",
-		URI_LIST: b"text/uri-list",
+		URI_LIST: URI_LIST_MIME.as_bytes(),
+		GNOME_COPIED_FILES: GNOME_COPIED_FILES_MIME.as_bytes(),
 
 		PNG_MIME: b"image/png",
 		X_KDE_PASSWORDMANAGERHINT: KDE_EXCLUSION_MIME.as_bytes(),
@@ -1057,7 +1059,8 @@ impl Clipboard {
 	}
 
 	pub(crate) fn get_file_list(&self, selection: LinuxClipboardKind) -> Result<Vec<PathBuf>> {
-		let result = self.inner.read(&[self.inner.atoms.URI_LIST], selection)?;
+		let formats = [self.inner.atoms.URI_LIST, self.inner.atoms.GNOME_COPIED_FILES];
+		let result = self.inner.read(&formats, selection)?;
 
 		Ok(paths_from_uri_list(result.bytes))
 	}
@@ -1070,9 +1073,14 @@ impl Clipboard {
 		exclude_from_history: bool,
 	) -> Result<()> {
 		let files = paths_to_uri_list(file_list)?;
-		let mut data = Vec::with_capacity(if exclude_from_history { 2 } else { 1 });
+		let gnome_files = gnome_copied_files_from_uri_list(&files);
+		let mut data = Vec::with_capacity(if exclude_from_history { 3 } else { 2 });
 
 		data.push(ClipboardData { bytes: files.into_bytes(), format: self.inner.atoms.URI_LIST });
+		data.push(ClipboardData {
+			bytes: gnome_files,
+			format: self.inner.atoms.GNOME_COPIED_FILES,
+		});
 		self.add_clipboard_exclusions(exclude_from_history, &mut data);
 
 		self.inner.write(data, selection, wait)


### PR DESCRIPTION
GNOME file managers such as Nautilus expect `x-special/gnome-copied-files` for file clipboard operations.

This change publishes both `text/uri-list` and the GNOME-specific format, and supports reading the GNOME format on X11 and Wayland. The existing `file_list` API is unchanged.